### PR TITLE
Feature/server buffer until sync

### DIFF
--- a/code/client/client.py
+++ b/code/client/client.py
@@ -289,6 +289,7 @@ class ClientListener:
             "type": "thread_message" if is_thread else "message",
             "data": {
                 "channel_id": message.channel.id,
+                "channel_name": message.channel.name,
                 "author": author,
                 "avatar_url": (
                     str(message.author.display_avatar.url)

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -71,7 +71,6 @@ class ServerReceiver:
         self._sitemap_task: asyncio.Task | None = None
         self._pending_msgs: dict[int, list[dict]] = {}
         self._pending_thread_msgs: List[Dict] = []
-        
         orig_on_connect = self.bot.on_connect
 
         async def _command_sync():
@@ -182,7 +181,7 @@ class ServerReceiver:
             comm = sitemap.get("community", {})
             rules_id = comm.get("rules_channel_id")
             updates_id = comm.get("public_updates_channel_id")
-            
+
             # ─── COMMUNITY SUPPORT CHECK ────────────────────────────────
             # Does the sitemap ask for community mode?
             want_comm = bool(comm.get("enabled"))
@@ -191,10 +190,9 @@ class ServerReceiver:
             if want_comm and not supports_comm:
                 logger.warning(
                     "Guild %s doesn’t support Community, some features will be disabled; Please enable it manually in the guild settings.",
-                    guild.name
+                    guild.name,
                 )
                 want_comm = False
-
 
             logger.debug(
                 "Sync #%d: sitemap has %d categories and %d standalone channels",
@@ -210,7 +208,8 @@ class ServerReceiver:
                 except Forbidden as e:
                     logger.warning(
                         "Cannot disable Community mode on guild %s (missing permission): %s",
-                        guild.id, e
+                        guild.id,
+                        e,
                     )
                 except Exception as e:
                     logger.error(
@@ -289,12 +288,14 @@ class ServerReceiver:
                             except Forbidden as e:
                                 logger.warning(
                                     "Cannot enable/update Community mode on guild %s (missing permission): %s",
-                                    guild.id, e
+                                    guild.id,
+                                    e,
                                 )
                             except Exception as e:
                                 logger.error(
                                     "Failed to enable/update Community mode on clone guild %s: %s",
-                                    guild.id, e
+                                    guild.id,
+                                    e,
                                 )
 
             if want_comm and rules_id and updates_id:
@@ -343,11 +344,10 @@ class ServerReceiver:
                         )
                         await self._cooldown()
 
-            removed_cat = await self._handle_removed_categories(guild, sitemap)
             removed_chan = await self._handle_removed_channels(
                 guild, self._parse_sitemap(sitemap)
             )
-
+            removed_cat = await self._handle_removed_categories(guild, sitemap)
             renamed_cat = await self._handle_renamed_categories(guild, sitemap)
 
             old_map = {
@@ -433,11 +433,10 @@ class ServerReceiver:
                         name=forum["name"], category=parent
                     )
                     logger.info(
-                        "Created forum channel '%s' (ID %d) under category '%s' for source %d",
+                        "Created forum channel %s #%d under category %s",
                         forum["name"],
                         clone_forum.id,
                         parent.name if parent else "standalone",
-                        orig_forum_id,
                     )
                     created_forums += 1
 
@@ -453,7 +452,9 @@ class ServerReceiver:
                 if not existed:
                     new_url = await self._recreate_webhook(orig_forum_id)
                     if not new_url:
-                        logger.error("Failed to create webhook for forum %s", orig_forum_id)
+                        logger.error(
+                            "Failed to create webhook for forum %s", orig_forum_id
+                        )
 
             incoming = self._parse_sitemap(sitemap)
             created_chan = renamed_chan = 0
@@ -490,14 +491,16 @@ class ServerReceiver:
                     await ch.edit(name=item["name"])
                     renamed_chan += 1
                     logger.info(
-                        "Renamed channel '%s' → '%s' (ID %d)",
+                        "Renamed channel %s → %s #%d",
                         old,
                         item["name"],
                         clone_id,
                     )
                     await self._cooldown()
 
-            moved_master = await self._handle_master_channel_moves(guild, incoming, old_map)
+            moved_master = await self._handle_master_channel_moves(
+                guild, incoming, old_map
+            )
 
             delete_remote = getattr(self.config, "DELETE_CLONED_THREADS", True)
             valid_threads = {rec["id"] for rec in sitemap.get("threads", [])}
@@ -552,7 +555,9 @@ class ServerReceiver:
                     continue
 
                 clone_tid = mapping["cloned_thread_id"]
-                ch = guild.get_channel(clone_tid) or await self.bot.fetch_channel(clone_tid)
+                ch = guild.get_channel(clone_tid) or await self.bot.fetch_channel(
+                    clone_tid
+                )
                 if ch and ch.name != new_name:
                     old = ch.name
                     try:
@@ -598,17 +603,17 @@ class ServerReceiver:
                 parts.append(f"Renamed {renamed_threads} threads")
             if not parts:
                 parts.append("No changes detected")
-                
+
         # Flush regular-message buffer
         for source_id, msgs in list(self._pending_msgs.items()):
             for msg in msgs:
-                await asyncio.sleep(0.5)               
+                await asyncio.sleep(0.5)
                 await self.forward_message(msg)
             self._pending_msgs.pop(source_id, None)
 
         # Flush thread-message buffer
         for data in list(self._pending_thread_msgs):
-            await asyncio.sleep(0.5)                   
+            await asyncio.sleep(0.5)
             await self.handle_forum_message(data)
         self._pending_thread_msgs.clear()
 
@@ -796,10 +801,8 @@ class ServerReceiver:
                     return c
         clone = await guild.create_category(original_name)
         logger.info(
-            "Created category '%s' for source %d → clone ID %d",
+            "Created category %s",
             original_name,
-            original_id,
-            clone.id,
         )
         self.db.upsert_category_mapping(
             original_id, original_name, clone.id, original_name
@@ -842,7 +845,9 @@ class ServerReceiver:
                         row["original_parent_category_id"],
                         row["cloned_parent_category_id"],
                     )
-                    logger.info("Re-created webhook for source %d", original_id)
+                    logger.info(
+                        "Re-created webhook for %s #%d", original_name, original_id
+                    )
                     await self._cooldown()
                     return original_id, clone_id, url
             break
@@ -854,24 +859,22 @@ class ServerReceiver:
         if channel_type == ChannelType.news.value:
             ch = await guild.create_text_channel(name=original_name, category=category)
             logger.info(
-                "Created Text Channel '%s' (ID %d) for source %d",
+                "Created Text Channel %s #%d",
                 original_name,
                 ch.id,
-                original_id,
             )
 
             if "NEWS" in guild.features:
                 try:
                     await ch.edit(type=ChannelType.news)
                     logger.info(
-                        "Converted '%s' (ID %d) to Announcement for source %d",
+                        "Converted '%s' #%d to type Announcement",
                         original_name,
                         ch.id,
-                        original_id,
                     )
                 except HTTPException as e:
                     logger.warning(
-                        "Failed to convert channel %d to Announcement: %s. Leaving as text.",
+                        "Failed to convert channel #%d to Announcement: %s. Leaving as text.",
                         ch.id,
                         e,
                     )
@@ -885,17 +888,16 @@ class ServerReceiver:
         else:
             ch = await guild.create_text_channel(name=original_name, category=category)
             logger.info(
-                "Created Text channel '%s' (ID %d) for source %d",
+                "Created Text channel %s #%d",
                 original_name,
                 ch.id,
-                original_id,
             )
 
         await self._cooldown()
 
         wh = await ch.create_webhook(name="Clonecord")
         url = f"https://discord.com/api/webhooks/{wh.id}/{wh.token}"
-        logger.info("Created webhook for source %d → %s", original_id, url)
+        logger.info("Created webhook in %s", original_name)
 
         self.db.upsert_channel_mapping(
             original_id,
@@ -970,15 +972,13 @@ class ServerReceiver:
             None,
         )
         if not row:
-            logger.error(
-                "No DB row for source %s; cannot recreate webhook", original_id
-            )
+            logger.error("No DB row for #%s; cannot recreate webhook, are we fully synced?", original_id)
             return None
 
         cloned_id = row["cloned_channel_id"]
         if not cloned_id:
             logger.error(
-                "No cloned_channel_id for source %s; cannot recreate webhook",
+                "No mapping found for #%s; cannot recreate webhook",
                 original_id,
             )
             return None
@@ -986,7 +986,7 @@ class ServerReceiver:
         guild = self.bot.get_guild(self.clone_guild_id)
         if not guild:
             logger.error(
-                "Clone guild %s not found; cannot recreate webhook for source %s",
+                "Clone guild %s not found; cannot recreate webhook for #%s",
                 self.clone_guild_id,
                 original_id,
             )
@@ -995,7 +995,7 @@ class ServerReceiver:
         ch = guild.get_channel(cloned_id)
         if not ch:
             logger.error(
-                "Clone channel %s not found in guild %s; cannot recreate webhook for source %s",
+                "Clone channel %s not found in guild %s; cannot recreate webhook for #%s",
                 cloned_id,
                 self.clone_guild_id,
                 original_id,
@@ -1015,170 +1015,144 @@ class ServerReceiver:
                 row["cloned_parent_category_id"],
             )
 
-            logger.info("Recreated webhook for source %s → %s", original_id, url)
+            logger.info("Recreated webhook for #%s", original_id)
             await self._cooldown()
             return url
 
         except Exception:
-            logger.exception("Failed to recreate webhook for source %s", original_id)
+            logger.exception("Failed to recreate webhook for #%s", original_id)
             return None
 
-    async def _recreate_forum_webhook(self, forum_map: dict) -> Webhook:
-        """
-        Given a forum_map row (from channel_mappings), recreate its webhook,
-        update the DB, and return a fresh Webhook object.
-        """
+    async def handle_forum_message(self, data: dict):
+        # Buffer forum messages during sync
+        if self._sync_lock.locked():
+            logger.info(
+                "Sync in progress; thread message from %s in thread '%s' will be sent after sync.",
+                data.get("author"),
+                data.get("thread_name"),
+            )
+            self._pending_thread_msgs.append(data)
+            return
+
         guild = self.bot.get_guild(self.clone_guild_id)
-        clone_forum = guild.get_channel(forum_map["cloned_channel_id"])
-        if clone_forum is None:
-            clone_forum = await self.bot.fetch_channel(forum_map["cloned_channel_id"])
+        if not guild:
+            logger.error("Clone guild %s not available", self.clone_guild_id)
+            return
 
-        new_wh = await clone_forum.create_webhook(name="Clonecord")
-        new_url = f"https://discord.com/api/webhooks/{new_wh.id}/{new_wh.token}"
+        forum_map = next(
+            (
+                r
+                for r in self.db.get_all_channel_mappings()
+                if r["original_channel_id"] == data["forum_id"]
+            ),
+            None,
+        )
+        if not forum_map:
+            logger.error("No forum mapping for %s", data["thread_name"])
+            return
 
-        self.db.upsert_channel_mapping(
-            forum_map["original_channel_id"],
-            forum_map["original_channel_name"],
-            forum_map["cloned_channel_id"],
-            new_url,
-            forum_map["original_parent_category_id"],
-            forum_map["cloned_parent_category_id"],
+        payload = self._build_webhook_payload(data)
+
+        thread_map = next(
+            (
+                r
+                for r in self.db.get_all_threads()
+                if r["original_thread_id"] == data["thread_id"]
+            ),
+            None,
         )
 
-        session = aiohttp.ClientSession()
-        return Webhook.from_url(new_url, session=session)
-
-    async def handle_forum_message(self, data: dict):
-            # Buffer forum messages during sync
-            if self._sync_lock.locked():
-                logger.info(
-                    "Sync in progress; forum message for forum %s thread %s will be sent after sync.",
-                    data.get("forum_id"), data.get("thread_id")
-                )
-                self._pending_thread_msgs.append(data)
-                return
-
-            logger.debug(
-                "Received forum_message: forum_id=%s thread_id=%s author=%s",
-                data["forum_id"], data["thread_id"], data["author"],
-            )
-
-            guild = self.bot.get_guild(self.clone_guild_id)
-            if not guild:
-                logger.error("Clone guild %s not available", self.clone_guild_id)
-                return
-
-            forum_map = next(
-                (
-                    r
-                    for r in self.db.get_all_channel_mappings()
-                    if r["original_channel_id"] == data["forum_id"]
-                ),
-                None,
-            )
-            if not forum_map:
-                logger.error("No forum mapping for %s", data["forum_id"])
-                return
-
-            payload = self._build_webhook_payload(data)
-
-            thread_map = next(
-                (
-                    r
-                    for r in self.db.get_all_threads()
-                    if r["original_thread_id"] == data["thread_id"]
-                ),
-                None,
-            )
-
-            clone_thread = None
-            if thread_map:
-                clone_thread = guild.get_channel(thread_map["cloned_thread_id"])
-                if not clone_thread:
-                    try:
-                        clone_thread = await self.bot.fetch_channel(
-                            thread_map["cloned_thread_id"]
-                        )
-                    except NotFound:
-                        logger.warning(
-                            "Cloned thread %s missing, recreating",
-                            thread_map["cloned_thread_id"],
-                        )
-                        self.db.delete_forum_thread_mapping(data["thread_id"])
-                        thread_map = None
-                        clone_thread = None
-
-            session = aiohttp.ClientSession()
-            wh = Webhook.from_url(forum_map["channel_webhook_url"], session=session)
-
-            if thread_map is None:
-                logger.info(
-                    "Creating new thread '%s' in forum %s by %s",
-                    data["thread_name"], data["forum_id"], data["author"],
-                )
-
-                cloned_parent = guild.get_channel(forum_map["cloned_channel_id"])
-
-                if isinstance(cloned_parent, discord.ForumChannel):
-                    base_url = forum_map["channel_webhook_url"]
-                    sep = "&" if "?" in base_url else "?"
-                    exec_url = f"{base_url}{sep}wait=true"
-
-                    async with session.post(
-                        exec_url, json={**payload, "thread_name": data["thread_name"]}
-                    ) as resp:
-                        if resp.status != 200:
-                            body = await resp.text()
-                            logger.error(
-                                "Webhook create-thread failed: %s %s", resp.status, body
-                            )
-                            await session.close()
-                            return
-                        data_json = await resp.json()
-
-                    new_thread_id = int(data_json["channel_id"])
-
-                elif isinstance(cloned_parent, discord.TextChannel):
-                    new_thread = await cloned_parent.create_thread(
-                        name=data["thread_name"],
-                        type=discord.ChannelType.public_thread,
-                        auto_archive_duration=1440,
-                    )
-                    new_thread_id = new_thread.id
-
-                    await wh.send(**payload, thread=new_thread, wait=True)
-
-                else:
-                    logger.error(
-                        "Cannot create thread in channel type %s", type(cloned_parent)
-                    )
-                    await session.close()
-                    return
-
-                self.db.upsert_forum_thread_mapping(
-                    data["thread_id"],
-                    data["thread_name"],
-                    new_thread_id,
-                    data["forum_id"],
-                    forum_map["cloned_channel_id"],
-                )
-
-            else:
-                logger.info(
-                    "Forwarding message to existing thread %s by %s",
-                    thread_map["cloned_thread_id"], data["author"],
-                )
+        clone_thread = None
+        if thread_map:
+            clone_thread = guild.get_channel(thread_map["cloned_thread_id"])
+            if not clone_thread:
                 try:
-                    await wh.send(**payload, thread=clone_thread, wait=True)
+                    clone_thread = await self.bot.fetch_channel(
+                        thread_map["cloned_thread_id"]
+                    )
                 except NotFound:
-                    new_url = await self._recreate_webhook(data["forum_id"])
-                    if not new_url:
+                    logger.warning(
+                        "Cloned thread %s missing, recreating",
+                        thread_map["thread_name"],
+                    )
+                    self.db.delete_forum_thread_mapping(data["thread_id"])
+                    thread_map = None
+                    clone_thread = None
+
+        session = aiohttp.ClientSession()
+        wh = Webhook.from_url(forum_map["channel_webhook_url"], session=session)
+
+        if thread_map is None:
+            logger.info(
+                "Creating thread '%s' in forum %s by %s",
+                data["thread_name"],
+                data["forum_id"],
+                data["author"],
+            )
+
+            cloned_parent = guild.get_channel(forum_map["cloned_channel_id"])
+
+            if isinstance(cloned_parent, discord.ForumChannel):
+                base_url = forum_map["channel_webhook_url"]
+                sep = "&" if "?" in base_url else "?"
+                exec_url = f"{base_url}{sep}wait=true"
+
+                async with session.post(
+                    exec_url, json={**payload, "thread_name": data["thread_name"]}
+                ) as resp:
+                    if resp.status != 200:
+                        body = await resp.text()
+                        logger.error(
+                            "Webhook create-thread failed: %s %s", resp.status, body
+                        )
                         await session.close()
                         return
-                    wh = Webhook.from_url(new_url, session=session)
-                    await wh.send(**payload, thread=clone_thread, wait=True)
+                    data_json = await resp.json()
 
-            await session.close()
+                new_thread_id = int(data_json["channel_id"])
+
+            elif isinstance(cloned_parent, discord.TextChannel):
+                new_thread = await cloned_parent.create_thread(
+                    name=data["thread_name"],
+                    type=discord.ChannelType.public_thread,
+                    auto_archive_duration=1440,
+                )
+                new_thread_id = new_thread.id
+
+                await wh.send(**payload, thread=new_thread, wait=True)
+
+            else:
+                logger.error(
+                    "Cannot create thread in channel type %s", type(cloned_parent)
+                )
+                await session.close()
+                return
+
+            self.db.upsert_forum_thread_mapping(
+                data["thread_id"],
+                data["thread_name"],
+                new_thread_id,
+                data["forum_id"],
+                forum_map["cloned_channel_id"],
+            )
+
+        else:
+            logger.info(
+                "Forwarding message to existing thread %s from %s",
+                data["thread_name"],
+                data["author"],
+            )
+            try:
+                await wh.send(**payload, thread=clone_thread, wait=True)
+            except NotFound:
+                new_url = await self._recreate_webhook(data["forum_id"])
+                if not new_url:
+                    await session.close()
+                    return
+                wh = Webhook.from_url(new_url, session=session)
+                await wh.send(**payload, thread=clone_thread, wait=True)
+
+        await session.close()
 
     async def handle_thread_delete(self, data: dict):
         """When a source thread is deleted, optionally delete its clone and always drop the DB mapping."""
@@ -1345,15 +1319,9 @@ class ServerReceiver:
             long_embed = Embed(description=text[:4096])
             # turn *all* embeds into dicts
             all_embeds = [long_embed] + embeds
-            return {
-                **base,
-                "embeds": [e.to_dict() for e in all_embeds]
-            }
-            
-        payload = {
-            **base,
-            "content": text or None
-        }
+            return {**base, "embeds": [e.to_dict() for e in all_embeds]}
+
+        payload = {**base, "content": text or None}
         if embeds:
             # convert all Embed instances to dicts
             payload["embeds"] = [e.to_dict() for e in embeds]
@@ -1377,13 +1345,16 @@ class ServerReceiver:
         if not url:
             if self._sync_lock.locked():
                 logger.info(
-                    "Sync in progress; message for %d will be sent after sync",
-                    source_id
+                    "Sync in progress; message in #%s from %s will be forwarded after sync",
+                    msg["channel_name"],
+                    msg["author"],
                 )
                 self._pending_msgs.setdefault(source_id, []).append(msg)
                 return
 
-            logger.warning("No webhook for %d, attempting to recreate", source_id)
+            logger.warning(
+                "No webhook for #%s, attempting to recreate", msg["channel_name"]
+            )
             url = await self._recreate_webhook(source_id)
             if not url:
                 return
@@ -1392,23 +1363,25 @@ class ServerReceiver:
         payload = self._build_webhook_payload(msg)
         if payload is None:
             logger.info(
-                "No webhook payload built for source %d; skipping",
-                source_id
+                "No webhook payload built for #%s; skipping", msg["channel_name"]
             )
             return
 
         if not payload.get("content") and not payload.get("embeds"):
-            logger.info("Skipping empty message for source %d", source_id)
+            logger.info("Skipping empty message for #%s", msg["channel_name"])
             return
 
         # Ensure serializable
         try:
             import json
+
             json.dumps(payload)
         except (TypeError, ValueError) as e:
             logger.error(
-                "Skipping message %s: payload not JSON serializable: %s; payload=%r",
-                source_id, e, payload
+                "Skipping message from #%s: payload not JSON serializable: %s; payload=%r",
+                msg["channel_name"],
+                e,
+                payload,
             )
             return
 
@@ -1417,7 +1390,11 @@ class ServerReceiver:
             try:
                 async with self.session.post(url, json=payload) as resp:
                     if resp.status in (200, 204):
-                        logger.info("Forwarded message for source %d", source_id)
+                        logger.info(
+                            "Forwarded message to #%s from %s",
+                            msg["channel_name"],
+                            msg["author"],
+                        )
                         return
 
                     if resp.status == 404 and attempt == 1:
@@ -1432,7 +1409,7 @@ class ServerReceiver:
                     return
 
             except Exception:
-                logger.exception("Error forwarding %d", source_id)
+                logger.exception("Error forwarding message to #%s", msg["channel_name"])
                 return
 
     async def _shutdown(self):


### PR DESCRIPTION
**Improve Sync Reliability by Buffering Messages**
When a server sync is first initiated, it may take some time to complete. During this window, incoming messages may target channels that haven’t yet been mapped or created.

**What This PR Does**
Introduces a message buffer to temporarily store incoming messages during the initial sync phase.

Once the sync is complete, all buffered messages are forwarded to their correct channels.

**Why It Matters**
This change prevents errors and lost messages that occur when trying to forward messages to channels that don’t exist yet. It ensures a more reliable and consistent synchronization experience, especially for busy servers with active chats.