### PR TITLE
Fix sitemap que and handle max guild channels | Add verify_structure command

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -18,8 +18,6 @@ body:
           required: true
         - label: Ensured I am using the latest version.
           required: true
-        - label: Enabled verbose logging.
-          required: true
   - type: textarea
     id: what-happened
     attributes:
@@ -35,18 +33,7 @@ body:
       options:
         - Windows
         - Linux
-        - MacOS
-        - Unraid
-    validations:
-      required: true
-  - type: dropdown
-    id: deployment
-    attributes:
-      label: What type of deployment do you use?
-      multiple: false
-      options:
-        - Docker container
-        - Binary (executable) file
+        - Other
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/3-help.yml
+++ b/.github/ISSUE_TEMPLATE/3-help.yml
@@ -18,8 +18,6 @@ body:
           required: true
         - label: Ensured I am using the latest version.
           required: true
-        - label: Enabled verbose logging.
-          required: true
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
### What’s Changed

- **Process Only the Latest Sitemap**

The queue now drops any outdated sitemap payloads and only processes the most recent one once the current sync finishes.

- **Respect Discord Channel & Category Limits**

We now enforce the 500‑channel per guild and 50‑channel per category caps. If a target category is full, new or moved channels automatically fall back to “standalone” (no category).

- **Enhanced Sync Logging**

Logs now clearly distinguish structural moves, “fallback to standalone” events, and skipped no‑ops, making it easier to audit each sync run.

- **New /verify_structure Command**

Added a slash command that reports any “orphan” channels or categories (present in Discord but not in your last sitemap) and, with a delete flag, can optionally purge them in one go.

- **Smarter Sync Triggers**

The on_guild_channel_update handler now only schedules a sync when a channel’s name or parent category actually changes—permission tweaks, topic edits, and other non‑structural updates are ignored.

