### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # ─── Python deps in server ───────────────────────────────────────
+  - package-ecosystem: "pip"
+    directory: "/code/server"
+    schedule:
+      interval: "weekly"
+
+  # ─── Dockerfile in server ──────────────────────────────────────
+  - package-ecosystem: "docker"
+    directory: "/code/server"
+    schedule:
+      interval: "weekly"
+
+  # ─── Python deps in client ─────────────────────────────────────
+  - package-ecosystem: "pip"
+    directory: "/code/client"
+    schedule:
+      interval: "weekly"
+
+  # ─── Dockerfile in client ──────────────────────────────────────
+  - package-ecosystem: "docker"
+    directory: "/code/client"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
**This PR introduces a .github/dependabot.yml that will:**

- Monitor Python dependencies in both /code/server and /code/client (weekly)
- Monitor Docker base‑image tags in both /code/server and /code/client (weekly)

**Automatically open pull requests to bump:**

- requirements.txt entries
- FROM lines in each Dockerfile

Once merged, Dependabot will keep our server & client images and Python libraries up to date, reduce manual work, and surface any security‑critical updates as PRs for review.