### PR TITLE
Feature/emoji cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ In the new folder, create `docker-compose.yml`:
 services:
   server:
     container_name: copycord-server
-    image: ghcr.io/copycord/copycord-server:v1.2.1
+    image: ghcr.io/copycord/copycord-server:v1.3.0
     environment:
       - SERVER_TOKEN=123456789123456789 # Discord bot token, must be invited into the cloned server
       - CLONE_GUILD_ID=123456789 # ID of the server you created to be cloned
@@ -88,7 +88,7 @@ services:
 
   client:
     container_name: copycord-client
-    image: ghcr.io/copycord/copycord-client:v1.2.1
+    image: ghcr.io/copycord/copycord-client:v1.3.0
     environment:
       - CLIENT_TOKEN=123456789123456789 # Discord user account token, see "Getting Started"
       - HOST_GUILD_ID=123456789 # ID of the server we wil be cloning

--- a/code/client/client.py
+++ b/code/client/client.py
@@ -123,6 +123,15 @@ class ClientListener:
             "standalone_channels": [],
             "forums": [],
             "threads": [],
+            "emojis": [
+                {
+                    "id": e.id,
+                    "name": e.name,
+                    "url": str(e.url),
+                    "animated": e.animated
+                }
+                for e in guild.emojis
+            ],
             "community": {
                 "enabled": guild.features and "COMMUNITY" in guild.features,
                 "rules_channel_id": (

--- a/code/common/config.py
+++ b/code/common/config.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("config")
 
 class Config:
     def __init__(self):
-        self.CURRENT_VERSION = "v1.2.1"
+        self.CURRENT_VERSION = "v1.3.0"
         self.GITHUB_API_LATEST = (
             "https://api.github.com/repos/Copycord/Copycord/releases/latest"
         )

--- a/code/common/db.py
+++ b/code/common/db.py
@@ -51,6 +51,17 @@ class DBManager:
             )
             """
         )
+        
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS emoji_mappings (
+              original_emoji_id   INTEGER PRIMARY KEY,
+              original_emoji_name TEXT    NOT NULL,
+              cloned_emoji_id     INTEGER UNIQUE,
+              cloned_emoji_name   TEXT    NOT NULL
+            );
+            """
+        )
         c.execute("""
             CREATE TABLE IF NOT EXISTS settings  (
                 id              INTEGER PRIMARY KEY CHECK (id = 1),
@@ -222,3 +233,27 @@ class DBManager:
         )
         self.conn.commit()
         return True
+
+    def get_all_emoji_mappings(self) -> list[sqlite3.Row]:
+        return self.conn.execute("SELECT * FROM emoji_mappings").fetchall()
+
+    def upsert_emoji_mapping(self,
+                             orig_id: int,
+                             orig_name: str,
+                             clone_id: int,
+                             clone_name: str):
+        self.conn.execute(
+            """INSERT OR REPLACE INTO emoji_mappings
+               (original_emoji_id, original_emoji_name,
+                cloned_emoji_id, cloned_emoji_name)
+               VALUES (?, ?, ?, ?)""",
+            (orig_id, orig_name, clone_id, clone_name),
+        )
+        self.conn.commit()
+
+    def delete_emoji_mapping(self, orig_id: int):
+        self.conn.execute(
+            "DELETE FROM emoji_mappings WHERE original_emoji_id = ?",
+            (orig_id,),
+        )
+        self.conn.commit()

--- a/code/server/requirements.txt
+++ b/code/server/requirements.txt
@@ -1,3 +1,4 @@
 py-cord==2.6.1
 websockets==11.0
 aiohttp==3.8.6
+Pillow==11.3.0

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -244,7 +244,7 @@ class ServerReceiver:
             # 2a) Orphaned mapping? (deleted manually in clone)
             if mapping and not cloned:
                 logger.warning(
-                    f"Stale mapping for emoji {mapping['original_emoji_name']}; will recreate"
+                    f"Emoji {mapping['original_emoji_name']} stored in mapping, but missing; will recreate"
                 )
                 self.db.delete_emoji_mapping(orig_id)
                 mapping = cloned = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   server:
     container_name: copycord-server
-    image: ghcr.io/copycord/copycord-server:v1.2.1
+    image: ghcr.io/copycord/copycord-server:v1.3.0
     environment:
       - SERVER_TOKEN=123456789123456789 # Discord bot token, must be invited into the cloned server
       - CLONE_GUILD_ID=123456789 # ID of the server you created to be cloned
@@ -14,7 +14,7 @@ services:
 
   client:
     container_name: copycord-client
-    image: ghcr.io/copycord/copycord-client:v1.2.1
+    image: ghcr.io/copycord/copycord-client:v1.3.0
     environment:
       - CLIENT_TOKEN=123456789123456789 # Discord user account token, see "Getting Started"
       - HOST_GUILD_ID=123456789 # ID of the server we wil be cloning


### PR DESCRIPTION
### Emoji Cloning Support
This PR introduces emoji cloning functionality.
Non-boosted servers are limited to 50 static and 50 animated custom emojis. If the host guild exceeds this limit, only the first 50 of each type are cloned; the rest are skipped.

To clone additional emojis, consider boosting the clone server to increase its emoji capacity.