### PR TITLE
fix(logging): rotate log file at 10 MB threshold

### DIFF
--- a/code/client/client.py
+++ b/code/client/client.py
@@ -2,6 +2,7 @@ import asyncio
 import signal
 from datetime import datetime, timezone
 import logging
+from logging.handlers import RotatingFileHandler
 from typing import Optional
 import discord
 from discord import ChannelType, MessageType
@@ -30,7 +31,12 @@ ch.setFormatter(formatter)
 root.addHandler(ch)
 
 log_file = os.path.join(LOG_DIR, "client.log")
-fh = logging.FileHandler(log_file, encoding="utf-8")
+fh = RotatingFileHandler(
+    log_file,
+    maxBytes=10 * 1024 * 1024,
+    backupCount=1,
+    encoding="utf-8",
+)
 fh.setFormatter(formatter)
 root.addHandler(fh)
 

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -1,6 +1,7 @@
 import signal
 import asyncio
 import logging
+from logging.handlers import RotatingFileHandler
 from typing import List, Optional, Tuple, Dict, Union
 import aiohttp
 import discord
@@ -42,7 +43,12 @@ ch.setFormatter(formatter)
 root.addHandler(ch)
 
 log_file = os.path.join(LOG_DIR, "server.log")
-fh = logging.FileHandler(log_file, encoding="utf-8")
+fh = RotatingFileHandler(
+    log_file,
+    maxBytes=10 * 1024 * 1024,
+    backupCount=1,
+    encoding="utf-8",
+)
 fh.setFormatter(formatter)
 root.addHandler(fh)
 


### PR DESCRIPTION
- Replace plain FileHandler with RotatingFileHandler
- Configure maxBytes=10 * 1024 * 1024 and backupCount=1
- Automatically back up and start a fresh log file when the size limit is reached