### PR TITLE
fix: use clone guild’s community flag for rules channel creation

### DIFF
--- a/code/server/server.py
+++ b/code/server/server.py
@@ -707,7 +707,7 @@ class ServerReceiver:
             incoming = self._parse_sitemap(sitemap)
             created_chan = renamed_chan = 0
             for item in incoming:
-                if comm.get("enabled") and item["id"] in (rules_id, updates_id):
+                if want_comm and item["id"] in (rules_id, updates_id):
                     continue
                 mapping = next(
                     (


### PR DESCRIPTION
- Ensures that when the clone guild is not a Community guild, the “rules” and “public-updates” channels are created as regular text channels
- Prevents skipping these channels based on the host guild’s Community setting