### PR TITLE
Fix buffered messages stalling sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ In the new folder, create `docker-compose.yml` and `.env`:
 services:
   server:
     container_name: copycord-server
-    image: ghcr.io/copycord/copycord-server:v1.6.0
+    image: ghcr.io/copycord/copycord-server:v1.6.1
     env_file:
       - .env
     volumes:
@@ -88,7 +88,7 @@ services:
 
   client:
     container_name: copycord-client
-    image: ghcr.io/copycord/copycord-client:v1.6.0
+    image: ghcr.io/copycord/copycord-client:v1.6.1
     env_file:
       - .env
     volumes:

--- a/code/client/client.py
+++ b/code/client/client.py
@@ -453,16 +453,14 @@ class ClientListener:
 
         return self._m_user.sub(repl, content)
 
-    def _sanitize_inline(
-        self,
-        s: str | None,
-        message: discord.Message | None = None,
-        id_map: dict[str, str] | None = None,
-    ) -> str | None:
+    def _sanitize_inline(self, s, message=None, id_map=None):
         if not s:
             return s
+        # Replace {mention} with actual mention text
+        if "{mention}" in s:
+            s = s.replace("{mention}", f"@{message.author.display_name}")
         if message:
-            s = self._humanize_user_mentions(s, message, id_to_name_override=id_map)
+            s = self._humanize_user_mentions(s, message, id_map)
         return s
 
     def _sanitize_embed_dict(

--- a/code/common/config.py
+++ b/code/common/config.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("config")
 
 class Config:
     def __init__(self):
-        self.CURRENT_VERSION = "v1.6.0"
+        self.CURRENT_VERSION = "v1.6.1"
         self.GITHUB_API_LATEST = (
             "https://api.github.com/repos/Copycord/Copycord/releases/latest"
         )

--- a/code/common/rate_limiter.py
+++ b/code/common/rate_limiter.py
@@ -86,8 +86,8 @@ class RateLimitManager:
             ActionType.EDIT_CHANNEL: (3, 15.0),
             ActionType.DELETE_CHANNEL: (3, 15.0),
             ActionType.THREAD: (2, 5.0),
-            ActionType.EMOJI: (2, 60.0),
-            ActionType.STICKER_CREATE: (2, 60.0),
+            ActionType.EMOJI: (1, 60.0),
+            ActionType.STICKER_CREATE: (1, 60.0),
         }
         self._limiters: Dict[ActionType, RateLimiter] = {
             a: RateLimiter(*cfg[a]) for a in cfg if a is not ActionType.WEBHOOK_MESSAGE

--- a/code/server/stickers.py
+++ b/code/server/stickers.py
@@ -351,16 +351,13 @@ class StickerManager:
         Returns True if the message was sent or queued (no further action needed by caller).
         Returns False if we prepared embeds in `msg` and the caller should continue with webhook send.
         """
-
-        # Buffer if mapping/channel isn't ready OR a sync is in progress
-        sync_locked = getattr(receiver, "_sync_lock", None)
-        if (not mapping) or (not ch) or (sync_locked and sync_locked.locked()):
+        if (not mapping) or (not ch):
+            msg["__buffered__"] = True
             receiver._pending_msgs.setdefault(source_id, []).append(msg)
             logger.info(
-                "[⏳] Queued sticker message for later: %s%s%s",
+                "[⏳] Queued sticker message for later: %s%s",
                 "mapping missing" if not mapping else "",
                 " and cloned channel not found" if mapping and not ch else "",
-                " (sync in progress)" if (sync_locked and sync_locked.locked()) else "",
             )
             return True
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/copycord/copycord-server:v1.6.0
+    image: ghcr.io/copycord/copycord-server:v1.6.1
     container_name: copycord-server
     env_file:
       - .env
@@ -8,7 +8,7 @@ services:
       - ./data:/data
 
   client:
-    image: ghcr.io/copycord/copycord-client:v1.6.0
+    image: ghcr.io/copycord/copycord-client:v1.6.1
     container_name: copycord-client
     env_file:
       - .env


### PR DESCRIPTION
### Summary
This pull request resolves an issue where buffered messages could delay ongoing sync operations. This was mainly an issue in large servers where hundreds of messages were buffered before the mapping was created.

**Key changes:**
- Send buffered messages as a background task
- Adjust rate limit handeler for Emoji and Sticker actions
- 