### PR TITLE
Ft(slash command) on join roles

### DIFF
--- a/code/server/commands.py
+++ b/code/server/commands.py
@@ -1356,9 +1356,15 @@ class CloneCommands(commands.Cog):
         ctx: discord.ApplicationContext,
         role: discord.Role = Option(discord.Role, "Role to add on join", required=True),
     ):
+        t0 = time.perf_counter()
         await ctx.defer(ephemeral=True)
         guild = ctx.guild
+
         if not guild:
+            logger.warning(
+                "onjoin_role: no guild context user_id=%s role_id=%s",
+                getattr(ctx.user, "id", "unknown"), getattr(role, "id", "unknown")
+            )
             return await ctx.followup.send(
                 embed=discord.Embed(
                     title="No Guild Context",
@@ -1368,7 +1374,12 @@ class CloneCommands(commands.Cog):
                 ephemeral=True,
             )
 
+
         if role.managed:
+            logger.warning(
+                "onjoin_role: reject managed role guild_id=%s role_id=%s",
+                guild.id, role.id
+            )
             return await ctx.followup.send(
                 embed=discord.Embed(
                     title="Managed Role Not Allowed",
@@ -1378,19 +1389,44 @@ class CloneCommands(commands.Cog):
                 ephemeral=True,
             )
 
-        added = self.db.toggle_onjoin_role(guild.id, role.id, ctx.user.id)
-        if added:
-            title = "On-Join Role Added"
-            desc = f"{role.mention} will be granted automatically to **new members** on join."
-            color = discord.Color.green()
-        else:
-            title = "On-Join Role Removed"
-            desc = f"{role.mention} will **no longer** be granted on join."
-            color = discord.Color.orange()
+        try:
+            added = self.db.toggle_onjoin_role(guild.id, role.id, ctx.user.id)
+            action = "ADDED" if added else "REMOVED"
+            logger.info(
+                "onjoin_role: %s guild_id=%s role_id=%s by user_id=%s",
+                action, guild.id, role.id, ctx.user.id
+            )
+        except Exception:
+            logger.exception(
+                "onjoin_role: DB toggle failed guild_id=%s role_id=%s user_id=%s",
+                guild.id, role.id, ctx.user.id
+            )
+            return await ctx.followup.send(
+                embed=discord.Embed(
+                    title="Database Error",
+                    description="Could not update on-join roles. Try again.",
+                    color=discord.Color.red(),
+                ),
+                ephemeral=True,
+            )
+
+        title = "On-Join Role Added" if added else "On-Join Role Removed"
+        desc = (
+            f"{role.mention} will be granted automatically to **new members** on join."
+            if added else
+            f"{role.mention} will **no longer** be granted on join."
+        )
+        color = discord.Color.green() if added else discord.Color.orange()
 
         await ctx.followup.send(
             embed=discord.Embed(title=title, description=desc, color=color),
             ephemeral=True,
+        )
+
+        dt = (time.perf_counter() - t0) * 1000
+        logger.debug(
+            "onjoin_role: finished guild_id=%s role_id=%s in %.1fms",
+            guild.id, role.id, dt
         )
 
 
@@ -1404,13 +1440,28 @@ class CloneCommands(commands.Cog):
         ctx: discord.ApplicationContext,
         clear: bool = Option(bool, "Delete ALL on-join roles for this server", required=False, default=False),
     ):
+        t0 = time.perf_counter()
         await ctx.defer(ephemeral=True)
         guild = ctx.guild
+
         if not guild:
+            logger.warning("onjoin_roles: no guild context user_id=%s", getattr(ctx.user, "id", "unknown"))
             return await ctx.followup.send("Run this inside a server.", ephemeral=True)
 
         if clear:
-            removed = self.db.clear_onjoin_roles(guild.id)
+            try:
+                removed = self.db.clear_onjoin_roles(guild.id)
+                logger.warning("onjoin_roles: cleared %s entries guild_id=%s by user_id=%s", removed, guild.id, ctx.user.id)
+            except Exception:
+                logger.exception("onjoin_roles: clear failed guild_id=%s", guild.id)
+                return await ctx.followup.send(
+                    embed=discord.Embed(
+                        title="Database Error",
+                        description="Could not clear on-join roles.",
+                        color=discord.Color.red(),
+                    ),
+                    ephemeral=True,
+                )
             return await ctx.followup.send(
                 embed=discord.Embed(
                     title="On-Join Roles Cleared",
@@ -1420,8 +1471,21 @@ class CloneCommands(commands.Cog):
                 ephemeral=True,
             )
 
-        role_ids = self.db.get_onjoin_roles(guild.id)
+        try:
+            role_ids = self.db.get_onjoin_roles(guild.id)
+        except Exception:
+            logger.exception("onjoin_roles: fetch failed guild_id=%s", guild.id)
+            return await ctx.followup.send(
+                embed=discord.Embed(
+                    title="Database Error",
+                    description="Could not load on-join roles.",
+                    color=discord.Color.red(),
+                ),
+                ephemeral=True,
+            )
+
         if not role_ids:
+            logger.info("onjoin_roles: none configured guild_id=%s", guild.id)
             return await ctx.followup.send(
                 embed=discord.Embed(
                     title="On-Join Roles",
@@ -1432,12 +1496,19 @@ class CloneCommands(commands.Cog):
             )
 
         lines = []
+        missing = 0
         for rid in role_ids:
             r = guild.get_role(rid)
             if r:
                 lines.append(f"• <@&{r.id}> (`{r.id}`)")
             else:
                 lines.append(f"• (missing role) `{rid}`")
+                missing += 1
+
+        logger.info(
+            "onjoin_roles: listed %s roles (missing=%s) guild_id=%s",
+            len(role_ids), missing, guild.id
+        )
 
         await ctx.followup.send(
             embed=discord.Embed(
@@ -1448,6 +1519,8 @@ class CloneCommands(commands.Cog):
             ephemeral=True,
         )
 
+        dt = (time.perf_counter() - t0) * 1000
+        logger.debug("onjoin_roles: finished guild_id=%s in %.1fms", guild.id, dt)
 
     @commands.slash_command(
         name="onjoin_sync",
@@ -1460,14 +1533,30 @@ class CloneCommands(commands.Cog):
         include_bots: bool = Option(bool, "Also give on-join roles to bots", required=False, default=False),
         dry_run: bool = Option(bool, "Show what would change without modifying roles", required=False, default=False),
     ):
+        t0 = time.perf_counter()
         await ctx.defer(ephemeral=True)
         guild = ctx.guild
+
         if not guild:
+            logger.warning("onjoin_sync: no guild context user_id=%s", getattr(ctx.user, "id", "unknown"))
             return await ctx.followup.send("Run this inside a server.", ephemeral=True)
 
-        role_ids = self.db.get_onjoin_roles(guild.id)
+        try:
+            role_ids = self.db.get_onjoin_roles(guild.id)
+        except Exception:
+            logger.exception("onjoin_sync: fetch roles failed guild_id=%s", guild.id)
+            return await ctx.followup.send(
+                embed=discord.Embed(
+                    title="Database Error",
+                    description="Could not load on-join roles.",
+                    color=discord.Color.red(),
+                ),
+                ephemeral=True,
+            )
+
         roles = [guild.get_role(rid) for rid in role_ids if guild.get_role(rid)]
         if not roles:
+            logger.info("onjoin_sync: no assignable roles guild_id=%s", guild.id)
             return await ctx.followup.send(
                 embed=discord.Embed(
                     title="No On-Join Roles",
@@ -1477,9 +1566,9 @@ class CloneCommands(commands.Cog):
                 ephemeral=True,
             )
 
-        # Safety: ensure bot has role-assign perms and role positions allow assignment
         me = guild.me or guild.get_member(self.bot.user.id)
         if not me or not guild.me.guild_permissions.manage_roles:
+            logger.warning("onjoin_sync: missing Manage Roles guild_id=%s", guild.id)
             return await ctx.followup.send(
                 embed=discord.Embed(
                     title="Missing Permission",
@@ -1491,30 +1580,47 @@ class CloneCommands(commands.Cog):
 
         assignable = [r for r in roles if r < me.top_role and not r.managed]
         skipped_roles = [r for r in roles if r not in assignable]
+        if skipped_roles:
+            logger.warning(
+                "onjoin_sync: skipped %s roles above bot or managed guild_id=%s role_ids=%s",
+                len(skipped_roles), guild.id, [r.id for r in skipped_roles]
+            )
 
         changed_users = 0
         changed_pairs = 0
         failed = 0
 
         members = list(guild.members)
+        total = len(members)
+        logger.debug("onjoin_sync: scanning %s members guild_id=%s", total, guild.id)
+
         for m in members:
             if m.bot and not include_bots:
                 continue
-            # Missing set = assignable roles user doesn't have
             missing = [r for r in assignable if r not in m.roles]
             if not missing:
                 continue
+
             if dry_run:
                 changed_pairs += len(missing)
                 changed_users += 1
+                logger.debug("onjoin_sync: DRY missing member_id=%s roles=%s", m.id, [r.id for r in missing])
                 continue
+
             try:
-                # add_roles allows passing multiple; discord.py handles rate-limiting
                 await m.add_roles(*missing, reason="Copycord onjoin_sync")
                 changed_pairs += len(missing)
                 changed_users += 1
+                logger.debug("onjoin_sync: added member_id=%s roles=%s", m.id, [r.id for r in missing])
             except Exception:
                 failed += 1
+                logger.exception("onjoin_sync: add_roles failed member_id=%s roles=%s", m.id, [r.id for r in missing])
+
+        dt = (time.perf_counter() - t0) * 1000
+        logger.info(
+            "onjoin_sync: done guild_id=%s changed_users=%s changed_pairs=%s failed=%s duration_ms=%.1f",
+            guild.id, changed_users, changed_pairs, failed, dt
+        )
 
         summary = (
             f"Members updated: **{changed_users}**\n"

--- a/code/server/helpers.py
+++ b/code/server/helpers.py
@@ -1144,28 +1144,64 @@ class OnCloneJoin:
         self.log = logging.getLogger("onclonejoin")
 
     async def handle_member_join(self, member: discord.Member) -> None:
+        t0 = time.perf_counter()
         try:
             guild = member.guild
             role_ids = self.db.get_onjoin_roles(guild.id)
             if not role_ids:
+                self.log.debug(
+                    "[🎭] Join roles: No on-join roles configured guild_id=%s member_id=%s",
+                    guild.id, member.id
+                )
                 return
 
             me = guild.me or guild.get_member(self.bot.user.id)
             if not me or not me.guild_permissions.manage_roles:
-                self.log.warning("Missing Manage Roles; cannot assign on-join roles.")
+                self.log.warning(
+                    "[🎭] Join roles: Missing Manage Roles; cannot assign on-join roles guild_id=%s",
+                    guild.id
+                )
                 return
 
-            # Only assign roles we can actually give (not managed, below our top role)
+            # Only roles we can give (not managed, below top role, member missing)
             assignable = []
+            skipped = []
             for rid in role_ids:
                 r = guild.get_role(rid)
-                if r and (not r.managed) and (r < me.top_role) and (r not in member.roles):
-                    assignable.append(r)
+                if not r:
+                    skipped.append((rid, "missing"))
+                    continue
+                if r.managed:
+                    skipped.append((rid, "managed"))
+                    continue
+                if not (r < me.top_role):
+                    skipped.append((rid, "above_bot"))
+                    continue
+                if r in member.roles:
+                    skipped.append((rid, "already_has"))
+                    continue
+                assignable.append(r)
 
-            if assignable:
-                await member.add_roles(*assignable, reason="OnCloneJoin: on-member-join")
+            if not assignable:
+                return
+
+            await member.add_roles(*assignable, reason="Copycord onjoin roles")
+            dt = (time.perf_counter() - t0) * 1000
+            self.log.info(
+                "[🎭] Join roles: assigned roles for %s (%s): %s duration_ms=%.1f",
+                member.name, member.id, [f"{r.id}:{r.name}" for r in assignable], dt
+            )
+            if skipped:
+                self.log.debug(
+                    "[🎭] Join roles: Skipped join roles member_id=%s details=%s",
+                    member.id, [(rid, reason) for rid, reason in skipped]
+                )
         except Exception:
-            self.log.error("Failed to handle on-member-join", exc_info=True)
+            self.log.exception(
+                "[🎭] Join roles: failed guild_id=%s member_id=%s",
+                getattr(member.guild, "id", "unknown"),
+                getattr(member, "id", "unknown"),
+            )
 
     async def sync_members(
         self,
@@ -1177,21 +1213,36 @@ class OnCloneJoin:
         """
         Return (changed_users, changed_pairs, failed, skipped_roles)
         """
+        t0 = time.perf_counter()
         role_ids = self.db.get_onjoin_roles(guild.id)
         roles = [guild.get_role(rid) for rid in role_ids if guild.get_role(rid)]
         if not roles:
+            self.log.info("[🎭] Role sync: No on-join roles configured guild_id=%s", guild.id)
             return (0, 0, 0, [])
 
         me = guild.me or guild.get_member(self.bot.user.id)
         if not me or not me.guild_permissions.manage_roles:
+            self.log.warning("[🎭] Role sync: Missing Manage Roles guild_id=%s", guild.id)
             raise PermissionError("Manage Roles missing")
 
         assignable = [r for r in roles if (not r.managed) and (r < me.top_role)]
         skipped_roles = [r for r in roles if r not in assignable]
+        if skipped_roles:
+            self.log.warning(
+                "[🎭] Role sync: Skipped non-assignable roles guild_id=%s role_ids=%s",
+                guild.id, [r.id for r in skipped_roles]
+            )
 
         changed_users = 0
         changed_pairs = 0
         failed = 0
+
+        # Per-member logs can get noisy; keep INFO summary + DEBUG details
+        total = len(guild.members)
+        self.log.info(
+            "[🎭] Role sync starting: guild_id=%s members=%s include_bots=%s dry_run=%s assignable=%s",
+            guild.id, total, include_bots, dry_run, [f"{r.id}:{r.name}" for r in assignable]
+        )
 
         for m in list(guild.members):
             if m.bot and not include_bots:
@@ -1199,16 +1250,36 @@ class OnCloneJoin:
             missing = [r for r in assignable if r not in m.roles]
             if not missing:
                 continue
+
             if dry_run:
                 changed_users += 1
                 changed_pairs += len(missing)
+                self.log.debug(
+                    "[🎭] Role sync: DRY member_id=%s missing_roles=%s",
+                    m.id, [f"{r.id}:{r.name}" for r in missing]
+                )
                 continue
+
             try:
-                await m.add_roles(*missing, reason="OnCloneJoin: sync")
+                await m.add_roles(*missing, reason="Copycord onjoin role sync")
                 changed_users += 1
                 changed_pairs += len(missing)
+                self.log.debug(
+                    "[🎭] Role sync: Added member_id=%s roles=%s",
+                    m.id, [f"{r.id}:{r.name}" for r in missing]
+                )
             except Exception:
                 failed += 1
+                self.log.exception(
+                    "[🎭] Role sync Error: add_roles failed member_id=%s roles=%s",
+                    m.id, [f"{r.id}:{r.name}" for r in missing]
+                )
+
+        dt = (time.perf_counter() - t0) * 1000
+        self.log.info(
+            "[🎭] Role sync finished: changed_users=%s changed_pairs=%s failed=%s duration_ms=%.1f",
+            changed_users, changed_pairs, failed, dt
+        )
 
         return (changed_users, changed_pairs, failed, skipped_roles)
 

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -43,7 +43,7 @@ from server.emojis import EmojiManager
 from server.stickers import StickerManager
 from server.roles import RoleManager
 from server.backfill import BackfillManager, BackfillTracker
-from server.helpers import OnJoinService, VerifyController, WebhookDMExporter
+from server.helpers import OnJoinService, VerifyController, WebhookDMExporter, OnCloneJoin
 from server.permission_sync import ChannelPermissionSync
 
 LOG_DIR = "/data"
@@ -108,6 +108,7 @@ class ServerReceiver:
         self.bot.event(self.on_ready)
         self.bot.event(self.on_webhooks_update)
         self.bot.event(self.on_guild_channel_delete)
+        self.bot.event(self.on_member_join)
         self._default_avatar_bytes: Optional[bytes] = None
         self._ws_task: asyncio.Task | None = None
         self._sitemap_task: asyncio.Task | None = None
@@ -139,6 +140,7 @@ class ServerReceiver:
         self._bf_throttle: dict[int, dict] = {}
         self._bf_delay = 2.0
         orig_on_connect = self.bot.on_connect
+        self.onclonejoin = OnCloneJoin(self.bot, self.db)
         self.bus = AdminBus(
             role="server", logger=logger, admin_ws_url=self.config.ADMIN_WS_URL
         )
@@ -282,6 +284,14 @@ class ServerReceiver:
             self._sitemap_task = asyncio.create_task(self.process_sitemap_queue())
             self._processor_started = True
             self._prune_old_messages_loop()
+
+    async def on_member_join(self, member: discord.Member):
+        try:
+            if int(member.guild.id) != int(self.clone_guild_id):
+                return
+        except Exception:
+            return
+        await self.onclonejoin.handle_member_join(member)
 
     def _canonical_webhook_name(self) -> str:
 

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -286,12 +286,24 @@ class ServerReceiver:
             self._prune_old_messages_loop()
 
     async def on_member_join(self, member: discord.Member):
+        g = getattr(member, "guild", None)
         try:
-            if int(member.guild.id) != int(self.clone_guild_id):
+            if not g:
                 return
+
+            if int(g.id) != int(self.clone_guild_id):
+                return
+
+            logger.info(
+                "[👤] %s (%s) has joined the server!",
+                member.name, member.id
+            )
+            await self.onclonejoin.handle_member_join(member)
         except Exception:
-            return
-        await self.onclonejoin.handle_member_join(member)
+            logger.exception(
+                "[👤] on_member_join: unhandled exception guild_id=%s member_id=%s",
+                getattr(g, "id", "unknown"), getattr(member, "id", "unknown")
+            )
 
     def _canonical_webhook_name(self) -> str:
 

--- a/docs/slash_commands.md
+++ b/docs/slash_commands.md
@@ -154,6 +154,54 @@ If enabled, you’ll receive a direct message with the new member’s details wh
 /onjoin_dm 123456789012345678
 ```
 
+### `/onjoin_role <role>`
+**Description:** Toggle an on-join role for the current server. Run once to add the role; run again with the same role to remove it.
+
+**Options:**
+- `role` *(required, role)* — The role to add or remove from the on-join list.
+
+**Usage Example:**
+```
+/onjoin_role @Member
+```
+
+**Notes:**
+- Multiple on-join roles are supported (run the command once per role).
+- Managed roles or roles above the bot’s top role cannot be assigned.
+- The bot must have **Manage Roles** permission.
+
+---
+
+### `/onjoin_roles [clear]`
+**Description:** List all configured on-join roles for the current server, or clear them all.
+
+**Options:**
+- `clear` *(optional, boolean, default: false)* — If `true`, removes **all** on-join roles for this server.
+
+**Usage Example:**
+```
+/onjoin_roles clear:true
+```
+
+**Notes:**
+- If `clear:false` (default), the command lists current on-join roles.
+- Missing or deleted roles are shown as “missing” in the list.
+
+
+---
+
+### `/onjoin_sync [include_bots] [dry_run]`
+**Description:** Scan all server members and add any **missing** on-join roles.
+
+**Options:**
+- `include_bots` *(optional, boolean, default: false)* — If `true`, bots are included in the sync.
+- `dry_run` *(optional, boolean, default: false)* — If `true`, shows what would change without modifying roles.
+
+**Usage Example:**
+```
+/onjoin_sync include_bots:true dry_run:true
+```
+
 ---
 ### `/purge_assets <type> <confirm>`
 **Description:** Purge all stickers, emojis, or roles.


### PR DESCRIPTION
This PR implements a feature for automatically assigning roles to new members when they join the clone server, including slash commands for management and a sync utility.

- Adds three new slash commands: /onjoin_role, /onjoin_roles, and /onjoin_sync for managing and applying on-join roles
- Implements database schema and methods for storing and retrieving on-join role configurations
- Creates an event handler that automatically assigns configured roles when members join the server