### PR TITLE
Fix message edit/delete event conditions to respect user settings

### DIFF
--- a/code/client/client.py
+++ b/code/client/client.py
@@ -1437,7 +1437,9 @@ class ClientListener:
         if payload.cached_message is not None:
             return
 
-        if not self.config.ENABLE_CLONING or not self.config.DELETE_MESSAGES:
+        if not self.config.ENABLE_CLONING:
+            return
+        if not self.config.DELETE_MESSAGES:
             return
 
         if (


### PR DESCRIPTION
Fix configuration checks in the `on_raw_message_edit` and `on_raw_message_delete` methods by splitting a combined conditional into two separate checks to respect user settings.