### PR TITLE
fix: add handling for forwarded embed messages

### DIFF
--- a/code/client/message_utils.py
+++ b/code/client/message_utils.py
@@ -7,6 +7,7 @@
 #  https://www.gnu.org/licenses/agpl-3.0.en.html
 # =============================================================================
 
+
 from __future__ import annotations
 import re
 from typing import Dict, List, Optional
@@ -14,6 +15,7 @@ from datetime import datetime, timezone
 import discord
 import aiohttp
 from discord import Member
+
 
 class MessageUtils:
     """
@@ -23,12 +25,15 @@ class MessageUtils:
     - sticker payload shaping
     - safe attribute extraction
     """
+
     _MENTION_RE = re.compile(r"<@!?(\d+)>")
 
     def __init__(self, bot: discord.Client):
         self.bot = bot
 
-    async def build_mention_map(self, message: discord.Message, embed_dicts: List[dict]) -> Dict[str, str]:
+    async def build_mention_map(
+        self, message: discord.Message, embed_dicts: List[dict]
+    ) -> Dict[str, str]:
         ids: set[str] = set()
 
         def _collect(s: Optional[str]):
@@ -100,7 +105,9 @@ class MessageUtils:
 
         return self._MENTION_RE.sub(repl, content)
 
-    def sanitize_inline(self, s: Optional[str], message: Optional[discord.Message] = None, id_map=None):
+    def sanitize_inline(
+        self, s: Optional[str], message: Optional[discord.Message] = None, id_map=None
+    ):
         if not s:
             return s
         if message and "{mention}" in s:
@@ -119,15 +126,21 @@ class MessageUtils:
         if "title" in e:
             e["title"] = self.sanitize_inline(e.get("title"), message, id_map)
         if "description" in e:
-            e["description"] = self.sanitize_inline(e.get("description"), message, id_map)
+            e["description"] = self.sanitize_inline(
+                e.get("description"), message, id_map
+            )
 
         if isinstance(e.get("author"), dict) and "name" in e["author"]:
             e["author"] = dict(e["author"])
-            e["author"]["name"] = self.sanitize_inline(e["author"].get("name"), message, id_map)
+            e["author"]["name"] = self.sanitize_inline(
+                e["author"].get("name"), message, id_map
+            )
 
         if isinstance(e.get("footer"), dict) and "text" in e["footer"]:
             e["footer"] = dict(e["footer"])
-            e["footer"]["text"] = self.sanitize_inline(e["footer"].get("text"), message, id_map)
+            e["footer"]["text"] = self.sanitize_inline(
+                e["footer"].get("text"), message, id_map
+            )
 
         if isinstance(e.get("fields"), list):
             new_fields = []
@@ -185,7 +198,7 @@ class MessageUtils:
                 continue
             attrs[name] = value
         return attrs
-    
+
     def serialize(self, message: discord.Message) -> dict:
         """Convert a Discord message into a serializable dict for dm export."""
         data = {
@@ -196,11 +209,15 @@ class MessageUtils:
                 "name": message.author.name,
                 "discriminator": message.author.discriminator,
                 "bot": message.author.bot,
-                "avatar_url": str(message.author.avatar.url) if message.author.avatar else None,
+                "avatar_url": (
+                    str(message.author.avatar.url) if message.author.avatar else None
+                ),
             },
             "content": self.humanize_user_mentions(message.content, message),
             "type": str(message.type),
-            "edited_timestamp": message.edited_at.isoformat() if message.edited_at else None,
+            "edited_timestamp": (
+                message.edited_at.isoformat() if message.edited_at else None
+            ),
         }
 
         if message.attachments:
@@ -226,7 +243,7 @@ class MessageUtils:
             data["stickers"] = self.stickers_payload(message.stickers)
 
         return data
-    
+
 
 class Snapshot:
     """All snapshot-related helpers, shims, and the REST fallback."""
@@ -363,10 +380,6 @@ class Snapshot:
         async def resolve_via_snapshot(
             bot, wrapper_msg, *, limit: int = 50, logger=None
         ):
-            """
-            Fetch recent messages in the wrapper's channel and unwrap the first usable
-            `message_snapshots[].message` if reference chaining fails.
-            """
             try:
                 chan = getattr(wrapper_msg, "channel", None)
                 chan_id = int(getattr(chan, "id", 0) or 0)
@@ -382,7 +395,6 @@ class Snapshot:
                             "[forward-snapshot] no token on bot.http; skipping fallback"
                         )
                     return None
-
 
                 url = f"https://discord.com/api/v9/channels/{chan_id}/messages?limit={int(limit)}"
                 headers = {"Authorization": token}
@@ -418,7 +430,9 @@ class Snapshot:
                     )
                     has_atts = bool(inner.get("attachments"))
                     has_stickers = bool(inner.get("stickers"))
-                    if has_text or has_atts or has_stickers:
+                    has_embeds = bool(inner.get("embeds"))
+
+                    if has_text or has_atts or has_stickers or has_embeds:
                         return Snapshot.Message(inner, wrapper_msg)
 
                 return None
@@ -429,10 +443,6 @@ class Snapshot:
 
 
 async def _resolve_forward(bot, wrapper_msg, max_depth: int = 4):
-    """
-    Follow .reference / forward wrappers to find the original message that actually
-    has real content we can forward. We ignore "embeds-only" shells.
-    """
     current = wrapper_msg
     seen = 0
 
@@ -442,8 +452,9 @@ async def _resolve_forward(bot, wrapper_msg, max_depth: int = 4):
         has_text = bool(raw_txt or sys_txt)
         has_atts = bool(getattr(current, "attachments", None))
         has_stks = bool(getattr(current, "stickers", None))
+        has_embeds = bool(getattr(current, "embeds", None))
 
-        if has_text or has_atts or has_stks:
+        if has_text or has_atts or has_stks or has_embeds:
             return current
 
         ref = getattr(current, "reference", None)
@@ -476,12 +487,11 @@ async def _resolve_forward(bot, wrapper_msg, max_depth: int = 4):
     if current is not None:
         raw_txt = (getattr(current, "content", "") or "").strip()
         sys_txt = (getattr(current, "system_content", "") or "").strip()
-        if (
-            raw_txt
-            or sys_txt
-            or getattr(current, "attachments", None)
-            or getattr(current, "stickers", None)
-        ):
+        has_atts = bool(getattr(current, "attachments", None))
+        has_stks = bool(getattr(current, "stickers", None))
+        has_embeds = bool(getattr(current, "embeds", None))
+
+        if raw_txt or sys_txt or has_atts or has_stks or has_embeds:
             return current
 
     return None


### PR DESCRIPTION
Adds handling for forwarded messages that contain only embeds (without text, attachments, or stickers). Previously, the code would skip over embed-only messages when resolving message forwards.