### PR TITLE
Add audioop-lts dependency for python_version >= "3.13"

### DIFF
--- a/code/client/requirements.txt
+++ b/code/client/requirements.txt
@@ -3,4 +3,4 @@ websockets==11.0.3
 PyYAML==6.0.2
 aiohttp>=3.9,<4
 tzdata==2025.2
-audioop-lts; python_version >= "3.13"
+audioop-lts==0.2.1; python_version >= "3.13"

--- a/code/server/requirements.txt
+++ b/code/server/requirements.txt
@@ -4,4 +4,4 @@ aiohttp>=3.9,<4
 Pillow==11.3.0
 PyYAML==6.0.2
 tzdata==2025.2
-audioop-lts; python_version >= "3.13"
+audioop-lts==0.2.1; python_version >= "3.13"


### PR DESCRIPTION
This PR adds the audioop-lts package as a dependency for Python 3.13 and later versions. The audioop module was removed from the Python standard library in Python 3.13, and audioop-lts provides a drop-in replacement to maintain compatibility with discord.py.