### PR TITLE
Replace mentions in topics and fix msg que

### DIFF
--- a/code/server/server.py
+++ b/code/server/server.py
@@ -7332,17 +7332,17 @@ class ServerReceiver:
             bf_targets = _bf_targets_for_source(source_id)
 
         if not rows:
+            # No mapping at all for this channel.
+            # Drop the message
             async with self._warn_lock:
                 if source_id not in self._unmapped_warned:
-                    logger.info(
-                        "[⌛] No mapping yet for channel %s (%s); msg from %s is queued and will be sent after sync",
+                    logger.debug(
+                        "[🚫] No mapping for channel %s (%s); dropping message from %s",
                         msg.get("channel_name"),
                         msg.get("channel_id"),
                         msg.get("author"),
                     )
                     self._unmapped_warned.add(source_id)
-            msg["__buffered__"] = True
-            self._pending_msgs.setdefault(source_id, []).append(msg)
             return
 
         for mapping in rows:


### PR DESCRIPTION
Adds topic sanitization for Discord channel topics and changes message queue behavior for unmapped channels.

Key Changes:

- Adds `_sanitize_topic` function to rewrite channel mentions and message links in channel topics using the existing `_sanitize_inline` helper
- Changes unmapped channel message handling from queuing to dropping messages