### PR TITLE
Add TAG_REPLY_MSG feature to include reply message tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Once started, open the web UI in your browser:
 | `DELETE_ROLES`                 | true    | Delete roles that no longer exist in the host                                                  |
 | `UPDATE_ROLES`                 | true    | Allow updating role properties after creation                                                  |
 | `DELETE_MESSAGES`              | true    | Delete cloned messages when the host message is deleted                                        |
+| `TAG_REPLY_MSG`                | false   | Adds a tag of the message that is being replied to                                             |
 | `MIRROR_CHANNEL_PERMISSIONS`   | false   | Mirror channel permissions from the host                                                       |
 | `CLONE_ROLES`                  | true    | Clone roles                                                                                    |
 | `CLONE_EMOJI`                  | true    | Clone emojis                                                                                   |

--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -203,6 +203,7 @@ BOOL_KEYS = [
     "DELETE_THREADS",
     "DELETE_MESSAGES",
     "EDIT_MESSAGES",
+    "TAG_REPLY_MSG",
     "REPOSITION_CHANNELS",
     "CLONE_VOICE",
     "CLONE_VOICE_PROPERTIES",
@@ -265,6 +266,7 @@ DEFAULTS: Dict[str, Union[bool, str]] = {
     "ANONYMIZE_USERS": False,
     "DISABLE_EVERYONE_MENTIONS": False,
     "DISABLE_ROLE_MENTIONS": False,
+    "TAG_REPLY_MSG": False,
 }
 
 

--- a/code/admin/templates/index.html
+++ b/code/admin/templates/index.html
@@ -233,6 +233,7 @@
     "ANONYMIZE_USERS": "When enabled, user identities will be anonymized with random names (e.g., SwiftFox123) and random avatar images.",
     "DISABLE_EVERYONE_MENTIONS": "When enabled, @everyone and @here mentions will be disabled in mirrored messages.",
     "DISABLE_ROLE_MENTIONS": "When enabled, role mentions will be disabled in mirrored messages to stop role pings.",
+    "TAG_REPLY_MSG": "When enabled, messages that are replies will include a tag of the message being replied to."
     } %}
 
     <div class="card" id="global-config-card">

--- a/code/client/client.py
+++ b/code/client/client.py
@@ -1018,8 +1018,6 @@ class ClientListener:
         if self.should_ignore(message):
             return
 
-        # logger.info("Full message dump:\n%s", dump_message_debug(message))
-
         raw = message.content or ""
         system = getattr(message, "system_content", "") or ""
 
@@ -1154,6 +1152,29 @@ class ClientListener:
             "components": components,
             "stickers": stickers_payload,
             "embeds": embeds,
+            **(
+                {
+                    "reference": {
+                        k: int(v)
+                        for k, v in {
+                            "message_id": getattr(
+                                getattr(src_msg, "reference", None), "message_id", None
+                            ),
+                            "channel_id": getattr(
+                                getattr(src_msg, "reference", None), "channel_id", None
+                            ),
+                            "guild_id": getattr(
+                                getattr(src_msg, "reference", None), "guild_id", None
+                            ),
+                        }.items()
+                        if v is not None
+                    }
+                }
+                if src_msg is not None
+                and getattr(src_msg, "reference", None)
+                and getattr(src_msg.reference, "message_id", None)
+                else {}
+            ),
         }
 
         if role_mentions:
@@ -1295,6 +1316,34 @@ class ClientListener:
                 "components": components,
                 "stickers": stickers_payload,
                 "embeds": embeds,
+                **(
+                    {
+                        "reference": {
+                            k: int(v)
+                            for k, v in {
+                                "message_id": getattr(
+                                    getattr(after, "reference", None),
+                                    "message_id",
+                                    None,
+                                ),
+                                "channel_id": getattr(
+                                    getattr(after, "reference", None),
+                                    "channel_id",
+                                    None,
+                                ),
+                                "guild_id": getattr(
+                                    getattr(after, "reference", None),
+                                    "guild_id",
+                                    None,
+                                ),
+                            }.items()
+                            if v is not None
+                        }
+                    }
+                    if getattr(after, "reference", None)
+                    and getattr(after.reference, "message_id", None)
+                    else {}
+                ),
                 **(
                     {
                         "thread_parent_id": after.channel.parent.id,
@@ -1442,6 +1491,29 @@ class ClientListener:
                 "content": content,
                 "timestamp": timestamp,
                 "embeds": embeds,
+                **(
+                    {
+                        "reference": {
+                            k: int(v)
+                            for k, v in {
+                                "message_id": getattr(
+                                    getattr(msg, "reference", None), "message_id", None
+                                ),
+                                "channel_id": getattr(
+                                    getattr(msg, "reference", None), "channel_id", None
+                                ),
+                                "guild_id": getattr(
+                                    getattr(msg, "reference", None), "guild_id", None
+                                ),
+                            }.items()
+                            if v is not None
+                        }
+                    }
+                    if msg is not None
+                    and getattr(msg, "reference", None)
+                    and getattr(msg.reference, "message_id", None)
+                    else {}
+                ),
                 **(
                     {
                         "thread_parent_id": channel.parent.id,

--- a/code/common/config.py
+++ b/code/common/config.py
@@ -123,6 +123,7 @@ class Config:
             "ANONYMIZE_USERS": False,
             "DISABLE_EVERYONE_MENTIONS": False,
             "DISABLE_ROLE_MENTIONS": False,
+            "TAG_REPLY_MSG": False,
         }
 
     async def setup_release_watcher(self, receiver, should_dm: bool = True):


### PR DESCRIPTION
Adds a reference at top of the cloned message, which includes a tag of the message being replied to.