### PR TITLE
Add `/env msg_cleanup` command to configure message retention period

### DIFF
--- a/docs/slash_commands.md
+++ b/docs/slash_commands.md
@@ -456,3 +456,17 @@ After running, all cloned messages revert to using the original author’s name 
 ```
 
 ---
+
+## Copycord Env (`/env`)
+
+#### `/msg_cleanup`
+
+**Description:** Set how many days stored messages are kept in the database before the automatic cleanup task removes them.
+
+**Example:**
+```text
+/env msg_cleanup days:7
+```
+
+---
+


### PR DESCRIPTION
New `/env` slash command group to set the custom environment variables that are available. Potentially more commands for this group in the future.

**What's New**

- `/env msg_cleanup` command to configure database message cleanup retention period