### PR TITLE
Refactor embed footer and author handling

### DIFF
--- a/code/server/server.py
+++ b/code/server/server.py
@@ -6210,18 +6210,14 @@ class ServerReceiver:
                     if emb.footer and getattr(emb.footer, "text", None):
                         emb.set_footer(
                             text=_apply_to_str(emb.footer.text),
-                            icon_url=getattr(
-                                emb.footer, "icon_url", discord.Embed.Empty
-                            ),
+                            icon_url=getattr(emb.footer, "icon_url", None),
                         )
 
                     if emb.author and getattr(emb.author, "name", None):
                         emb.set_author(
                             name=_apply_to_str(emb.author.name),
-                            url=getattr(emb.author, "url", discord.Embed.Empty),
-                            icon_url=getattr(
-                                emb.author, "icon_url", discord.Embed.Empty
-                            ),
+                            url=getattr(emb.author, "url", None),
+                            icon_url=getattr(emb.author, "icon_url", None),
                         )
 
                     for f in emb.fields:
@@ -6234,6 +6230,7 @@ class ServerReceiver:
                     continue
 
         return text, embeds
+
 
     def _sanitize_inline(
         self,


### PR DESCRIPTION
This PR refactors embed footer and author handling by replacing discord.Embed.Empty with None as the default value for optional parameters in set_footer() and set_author() calls. This is a code simplification that maintains the same functional behavior, as both values have equivalent semantics in discord.py when passed to these optional parameters. The change improves code readability by using the more Pythonic None instead of a library-specific sentinel value.