### PR TITLE
Dedup forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ copycord/
 ```yaml
 services:
   admin:
-    image: ghcr.io/copycord/copycord:v3.14.1
+    image: ghcr.io/copycord/copycord:v3.14.2
     container_name: copycord-admin
     environment:
       - ROLE=admin
@@ -150,7 +150,7 @@ services:
     restart: unless-stopped
 
   server:
-    image: ghcr.io/copycord/copycord:v3.14.1
+    image: ghcr.io/copycord/copycord:v3.14.2
     container_name: copycord-server
     environment:
       - ROLE=server
@@ -161,7 +161,7 @@ services:
     restart: unless-stopped
 
   client:
-    image: ghcr.io/copycord/copycord:v3.14.1
+    image: ghcr.io/copycord/copycord:v3.14.2
     container_name: copycord-client
     environment:
       - ROLE=client

--- a/code/client/forwarding.py
+++ b/code/client/forwarding.py
@@ -1948,6 +1948,25 @@ class ForwardingManager:
                     rule.rule_id,
                 )
 
+        msg_id = attrs.get("message_id")
+        if msg_id and self.db:
+            try:
+                if self.db.has_forwarding_event(
+                    rule_id=rule.rule_id,
+                    source_message_id=int(msg_id),
+                ):
+                    self.log.warning(
+                        "[⏩] DB dedup blocked duplicate webhook | rule_id=%s label=%s message_id=%s channel=%s attempt=%s",
+                        rule.rule_id,
+                        rule.label,
+                        msg_id,
+                        attrs.get("channel_name"),
+                        attempt,
+                    )
+                    return
+            except Exception:
+                self.log.debug("[⏩] DB dedup check failed, proceeding", exc_info=True)
+
         status, body, retry_after = await _post_with_discord_429_retry(
             session, url, payload
         )

--- a/code/client/forwarding.py
+++ b/code/client/forwarding.py
@@ -1077,7 +1077,8 @@ class ForwardingManager:
             return
         if provider == "discord":
             await self._send_discord_webhook(
-                rule=job.rule, attrs=job.attrs, session=session
+                rule=job.rule, attrs=job.attrs, session=session,
+                attempt=job.attempts,
             )
             return
 
@@ -1112,8 +1113,8 @@ class ForwardingManager:
         else:
             delay = 0.5 * (2 ** (job.attempts - 1))
 
-        delay *= 0.8 + random.random() * 0.4
         delay = min(float(self._retry_max_delay), delay)
+        delay *= 0.8 + random.random() * 0.4
 
         self.log.warning(
             "[⏩] Requeueing job | provider=%s message_id=%s attempt=%s delay=%.2fs",
@@ -1133,6 +1134,7 @@ class ForwardingManager:
             await asyncio.sleep(max(0.0, float(delay)))
             if self._closing:
                 return
+            self._dedup_touch(job.message_id, job.rule.rule_id)
             q = self._queues.get(provider)
             if not q:
                 return
@@ -1843,6 +1845,7 @@ class ForwardingManager:
         rule: ForwardingRule,
         attrs: dict,
         session: aiohttp.ClientSession,
+        attempt: int = 0,
     ) -> None:
         url = (rule.config.get("url") or "").strip()
         if not url:
@@ -1973,11 +1976,12 @@ class ForwardingManager:
             return
 
         self.log.info(
-            "[⏩] Discord webhook forward OK | rule_id=%s label=%s message_id=%s channel=%s",
+            "[⏩] Discord webhook forward OK | rule_id=%s label=%s message_id=%s channel=%s attempt=%s",
             rule.rule_id,
             rule.label,
             attrs.get("message_id"),
             attrs.get("channel_name"),
+            attempt,
         )
         try:
             self.db.record_forwarding_event(

--- a/code/common/config.py
+++ b/code/common/config.py
@@ -15,7 +15,7 @@ from typing import Optional
 from common.db import DBManager
 
 logger = logging.getLogger(__name__)
-CURRENT_VERSION = "v3.14.1"
+CURRENT_VERSION = "v3.14.2"
 
 
 class Config:

--- a/code/common/db.py
+++ b/code/common/db.py
@@ -933,6 +933,7 @@ class DBManager:
                 "CREATE INDEX IF NOT EXISTS idx_forwarding_events_rule ON forwarding_events(rule_id);",
                 "CREATE INDEX IF NOT EXISTS idx_forwarding_events_guild ON forwarding_events(guild_id);",
                 "CREATE INDEX IF NOT EXISTS idx_forwarding_events_created ON forwarding_events(created_at);",
+                "CREATE INDEX IF NOT EXISTS idx_forwarding_events_rule_msg ON forwarding_events(rule_id, source_message_id);",
             ],
         )
         self._ensure_table(
@@ -5042,6 +5043,20 @@ class DBManager:
                 ),
             )
         return eid
+
+    def has_forwarding_event(
+        self,
+        *,
+        rule_id: str,
+        source_message_id: int,
+    ) -> bool:
+        """Check whether a forwarding event already exists for this rule + message."""
+        with self.lock:
+            row = self.conn.execute(
+                "SELECT 1 FROM forwarding_events WHERE rule_id=? AND source_message_id=? LIMIT 1",
+                (rule_id, int(source_message_id)),
+            ).fetchone()
+        return row is not None
 
     def count_forwarded_messages(self) -> int:
         """

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -8196,6 +8196,10 @@ class ServerReceiver:
                         )
                         continue
 
+                    orig_gid = int(
+                        mapping.get("original_guild_id") or host_guild_id or 0
+                    )
+
                     _fwd_blacklist = self._get_channel_name_blacklist(
                         orig_gid, clone_gid
                     )
@@ -8211,9 +8215,6 @@ class ServerReceiver:
                         continue
 
                     try:
-                        orig_gid = int(
-                            mapping.get("original_guild_id") or host_guild_id or 0
-                        )
                         content_to_check = msg.get("content", "") or ""
 
                         should_block, blocked_keyword = self._should_block_for_mapping(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   admin:
-    image: ghcr.io/copycord/copycord:v3.14.1
+    image: ghcr.io/copycord/copycord:v3.14.2
     container_name: copycord-admin
     environment:
       - ROLE=admin
@@ -11,7 +11,7 @@ services:
       - ./data:/data
 
   server:
-    image: ghcr.io/copycord/copycord:v3.14.1
+    image: ghcr.io/copycord/copycord:v3.14.2
     container_name: copycord-server
     environment:
       - ROLE=server
@@ -21,7 +21,7 @@ services:
       - admin
 
   client:
-    image: ghcr.io/copycord/copycord:v3.14.1
+    image: ghcr.io/copycord/copycord:v3.14.2
     container_name: copycord-client
     environment:
       - ROLE=client


### PR DESCRIPTION
Attempted to improve deduplication in the Forwarding service for high-volume rules that were triggering rate limits and causing duplicate messages.