### PR TITLE
Added explicit mimetypes.add_type() calls

### DIFF
--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 from collections import deque
 import contextlib
+import mimetypes
 import json
 import os
 import sqlite3
@@ -276,6 +277,8 @@ DEFAULTS: Dict[str, Union[bool, str]] = {
 }
 
 app = FastAPI(title=APP_TITLE)
+mimetypes.add_type("application/javascript", ".js")
+mimetypes.add_type("text/css", ".css")
 app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 templates.env.globals.setdefault("links", {})


### PR DESCRIPTION
On some Windows machines, the registry maps .js to text/plain. Python's mimetypes module reads from the registry, and Starlette's StaticFiles uses mimetypes.guess_type() to set the Content-Type header. When it returns text/plain for .js files, the browser refuses to execute them as ES modules.

Fix: Added explicit mimetypes.add_type() calls in app.py before the StaticFiles mount, ensuring .js and .css files always get the correct MIME types regardless of Windows registry state.