### PR TITLE
Add time support to backfill date filters and ignore cloned messages toggle

### DIFF
--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -3287,6 +3287,14 @@ async def api_backfill_start(payload: dict = Body(...)):
         if after_ts and not data.get("after_iso"):
             data["after_iso"] = str(after_ts)
 
+    if payload.get("ignore_cloned"):
+        try:
+            exclude = db.get_cloned_original_ids_for_channel(channel_id, cloned_guild_id)
+            if exclude:
+                data["exclude_ids"] = [str(mid) for mid in exclude]
+        except Exception:
+            pass
+
     res = await _ws_cmd(CLIENT_AGENT_URL, {"type": "clone_messages", "data": data})
     if not res.get("ok", True):
         await locks.release(channel_id, cloned_guild_id)
@@ -3368,6 +3376,13 @@ async def api_backfill_start_batch(payload: dict = Body(...)):
                 data["after_id"] = str(after_id)
             if after_ts and not data.get("after_iso"):
                 data["after_iso"] = str(after_ts)
+        if payload.get("ignore_cloned"):
+            try:
+                exclude = db.get_cloned_original_ids_for_channel(cid, cloned_guild_id)
+                if exclude:
+                    data["exclude_ids"] = [str(mid) for mid in exclude]
+            except Exception:
+                pass
         return data
 
     results, started, locked, failed = [], 0, 0, 0

--- a/code/admin/frontend/src/js/channels.js
+++ b/code/admin/frontend/src/js/channels.js
@@ -202,16 +202,22 @@
     form.reset();
 
     const sinceEl = dlg.querySelector("#bf-batch-since");
+    const sinceTimeEl = dlg.querySelector("#bf-batch-since-time");
     const lastEl = dlg.querySelector("#bf-batch-lastn");
     const fromEl = dlg.querySelector("#bf-batch-from");
+    const fromTimeEl = dlg.querySelector("#bf-batch-from-time");
     const toEl = dlg.querySelector("#bf-batch-to");
+    const toTimeEl = dlg.querySelector("#bf-batch-to-time");
     const rowBetween = dlg.querySelector(".bf-row-between");
 
     const setMode = (mode) => {
       if (sinceEl) sinceEl.disabled = mode !== "since";
+      if (sinceTimeEl) sinceTimeEl.disabled = mode !== "since";
       if (lastEl) lastEl.disabled = mode !== "last";
       if (fromEl) fromEl.disabled = mode !== "between";
+      if (fromTimeEl) fromTimeEl.disabled = mode !== "between";
       if (toEl) toEl.disabled = mode !== "between";
+      if (toTimeEl) toTimeEl.disabled = mode !== "between";
       rowBetween?.classList.toggle("is-active", mode === "between");
     };
 
@@ -5040,10 +5046,17 @@
     const day = String(d.getDate()).padStart(2, "0");
     return `${y}-${m}-${day}`;
   }
-  function startOfDayIsoLocal(dateStr) {
-    return `${dateStr}T00:00`;
+  function combineDateAndTime(dateStr, timeStr) {
+    if (!dateStr) return "";
+    const t = (timeStr || "").trim();
+    return t ? `${dateStr}T${t}` : `${dateStr}T00:00`;
   }
-  function nextDayStartIsoLocal(dateStr) {
+  function startOfDayIsoLocal(dateStr, timeStr) {
+    return combineDateAndTime(dateStr, timeStr);
+  }
+  function nextDayStartIsoLocal(dateStr, timeStr) {
+    const t = (timeStr || "").trim();
+    if (t) return `${dateStr}T${t}`;
     const d = new Date(`${dateStr}T00:00`);
     d.setDate(d.getDate() + 1);
     return `${fmtYYYYMMDD(d)}T00:00`;
@@ -5240,9 +5253,12 @@
 
     const radios = dlg.querySelectorAll('input[name="mode"]');
     const sinceEl = dlg.querySelector("#bf-since");
+    const sinceTimeEl = dlg.querySelector("#bf-since-time");
     const lastEl = dlg.querySelector("#bf-lastn");
     const fromEl = dlg.querySelector("#bf-from");
+    const fromTimeEl = dlg.querySelector("#bf-from-time");
     const toEl = dlg.querySelector("#bf-to");
+    const toTimeEl = dlg.querySelector("#bf-to-time");
 
     const rowSince = sinceEl?.closest(".indent");
     const rowLast = lastEl?.closest(".indent");
@@ -5264,9 +5280,12 @@
       const mode =
         dlg.querySelector('input[name="mode"]:checked')?.value || "all";
       if (sinceEl) sinceEl.disabled = mode !== "since";
+      if (sinceTimeEl) sinceTimeEl.disabled = mode !== "since";
       if (lastEl) lastEl.disabled = mode !== "last";
       if (fromEl) fromEl.disabled = mode !== "between";
+      if (fromTimeEl) fromTimeEl.disabled = mode !== "between";
       if (toEl) toEl.disabled = mode !== "between";
+      if (toTimeEl) toTimeEl.disabled = mode !== "between";
 
       rowSince?.classList.toggle("is-active", mode === "since");
       rowLast?.classList.toggle("is-active", mode === "last");
@@ -5309,9 +5328,12 @@
       const mode =
         dlg.querySelector('input[name="mode"]:checked')?.value || "all";
       const sinceRaw = (sinceEl?.value || "").trim();
+      const sinceTimeRaw = (sinceTimeEl?.value || "").trim();
       const lastRaw = (lastEl?.value || "").trim();
       const fromRaw = (fromEl?.value || "").trim();
+      const fromTimeRaw = (fromTimeEl?.value || "").trim();
       const toRaw = (toEl?.value || "").trim();
+      const toTimeRaw = (toTimeEl?.value || "").trim();
 
       const lastVal = Number.parseInt(lastRaw, 10);
       const lastOk = Number.isFinite(lastVal) && lastVal > 0;
@@ -5348,18 +5370,20 @@
       setCloneLaunching(cloneId, true);
 
       const mappingId = mappingSel?.value || "";
+      const ignoreCloned = !!dlg.querySelector("#bf-ignore-cloned")?.checked;
       const body = {
         channel_id: cloneId,
         mapping_id: mappingId,
         mode,
-        ...(mode === "since" ? { since: startOfDayIsoLocal(sinceRaw) } : {}),
+        ...(mode === "since" ? { since: startOfDayIsoLocal(sinceRaw, sinceTimeRaw) } : {}),
         ...(mode === "last" ? { last_n: lastVal } : {}),
         ...(mode === "between"
           ? {
-              since: startOfDayIsoLocal(fromRaw),
-              before_iso: nextDayStartIsoLocal(toRaw),
+              since: startOfDayIsoLocal(fromRaw, fromTimeRaw),
+              before_iso: nextDayStartIsoLocal(toRaw, toTimeRaw),
             }
           : {}),
+        ...(ignoreCloned ? { ignore_cloned: true } : {}),
       };
 
       dbg("[REST] POST /api/backfill/start →", body);
@@ -5473,22 +5497,25 @@
             <input type="radio" name="mode" value="since">
             Since date/time
           </label>
-          <div class="indent">
+          <div class="indent bf-date-time-row">
             <input class="input" type="date" id="bf-batch-since" name="since" disabled>
+            <input class="input bf-time" type="time" id="bf-batch-since-time" disabled>
           </div>
-  
+
           <label class="radio">
             <input type="radio" name="mode" value="between">
             Between dates
           </label>
           <div class="indent bf-row-between">
-            <div class="bf-dual">
+            <div class="bf-dual bf-date-time-row">
               <label class="sr-only" for="bf-batch-from">From</label>
               <input class="input" type="date" id="bf-batch-from" disabled>
+              <input class="input bf-time" type="time" id="bf-batch-from-time" disabled>
             </div>
-            <div class="bf-dual" style="margin-top:8px">
+            <div class="bf-dual bf-date-time-row" style="margin-top:8px">
               <label class="sr-only" for="bf-batch-to">To</label>
               <input class="input" type="date" id="bf-batch-to" disabled>
+              <input class="input bf-time" type="time" id="bf-batch-to-time" disabled>
             </div>
           </div>
   
@@ -5501,7 +5528,19 @@
           </div>
         </fieldset>
 
-    <fieldset class="field bf-field" style="margin-top:12px">
+    <fieldset class="field bf-field" style="margin-top:8px">
+      <legend>Settings</legend>
+      <label class="checkbox-label has-tip">
+        <input type="checkbox" id="bf-batch-ignore-cloned" name="ignore_cloned">
+        <span>Ignore cloned messages</span>
+        <button class="info-dot" type="button" aria-describedby="tip-bf-batch-ignore"></button>
+        <div id="tip-bf-batch-ignore" class="tip-bubble" role="tooltip" aria-hidden="true">
+          Filters out already-cloned messages using the local DB. Disable DB_CLEANUP_MSG in mapping settings to keep records intact.
+        </div>
+      </label>
+    </fieldset>
+
+    <fieldset class="field bf-field" style="margin-top:8px">
       <legend>Mode</legend>
 
       <label class="radio has-tip">
@@ -5605,18 +5644,27 @@
         "resume";
 
       const sinceEl = dlg.querySelector("#bf-batch-since");
+      const sinceTimeEl = dlg.querySelector("#bf-batch-since-time");
       const lastEl = dlg.querySelector("#bf-batch-lastn");
       const fromEl = dlg.querySelector("#bf-batch-from");
+      const fromTimeEl = dlg.querySelector("#bf-batch-from-time");
       const toEl = dlg.querySelector("#bf-batch-to");
+      const toTimeEl = dlg.querySelector("#bf-batch-to-time");
 
-      const _startOfDayIsoLocal = (d) =>
+      const _combine = (d, t) => {
+        const time = (t || "").trim();
+        return time ? `${d}T${time}` : `${d}T00:00`;
+      };
+      const _startIso = (d, t) =>
         typeof startOfDayIsoLocal === "function"
-          ? startOfDayIsoLocal(d)
-          : `${d}T00:00`;
-      const _nextDayStartIsoLocal = (d) =>
+          ? startOfDayIsoLocal(d, t)
+          : _combine(d, t);
+      const _endIso = (d, t) =>
         typeof nextDayStartIsoLocal === "function"
-          ? nextDayStartIsoLocal(d)
+          ? nextDayStartIsoLocal(d, t)
           : (() => {
+              const time = (t || "").trim();
+              if (time) return `${d}T${time}`;
               const dt = new Date(`${d}T00:00`);
               dt.setDate(dt.getDate() + 1);
               const y = dt.getFullYear(),
@@ -5633,7 +5681,7 @@
           sinceEl?.focus();
           return;
         }
-        base.after_iso = _startOfDayIsoLocal(since);
+        base.after_iso = _startIso(since, (sinceTimeEl?.value || "").trim());
       } else if (mode === "last") {
         const n = parseInt((lastEl?.value || "").trim(), 10);
         if (!Number.isFinite(n) || n <= 0) {
@@ -5660,9 +5708,12 @@
         ) {
           return;
         }
-        base.after_iso = _startOfDayIsoLocal(from);
-        base.before_iso = _nextDayStartIsoLocal(to);
+        base.after_iso = _startIso(from, (fromTimeEl?.value || "").trim());
+        base.before_iso = _endIso(to, (toTimeEl?.value || "").trim());
       }
+
+      const ignoreCloned = !!dlg.querySelector("#bf-batch-ignore-cloned")?.checked;
+      if (ignoreCloned) base.ignore_cloned = true;
 
       startBtn.disabled = true;
 

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -2733,9 +2733,20 @@ body {
   color: var(--muted, #c9c3ff);
   font-size: 0.95rem;
 }
-.bf-card .input[type='datetime-local'],
 .bf-card .input[type='number'] {
-  width: 260px;
+  width: 160px;
+}
+.bf-date-time-row {
+  display: flex !important;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: nowrap !important;
+}
+.bf-card .input[type='date'] {
+  width: 160px;
+}
+.bf-card .input.bf-time {
+  width: 120px;
 }
 .indent {
   margin: 6px 0 12px 28px;
@@ -2745,6 +2756,15 @@ body {
   align-items: center;
   gap: 8px;
   margin: 6px 0;
+}
+.bf-card .checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 6px 0;
+}
+.bf-card .checkbox-label input[type="checkbox"] {
+  margin: 0;
 }
 .modal.bf-modal {
   display: none;
@@ -3780,10 +3800,17 @@ body {
   gap: 8px;
   margin: 8px 0 12px;
 }
+#backfill-dialog input[type='date'] {
+  width: 160px;
+  max-width: 160px;
+}
+#backfill-dialog input[type='time'] {
+  width: 120px;
+  max-width: 120px;
+}
 #backfill-dialog input[type='date'],
+#backfill-dialog input[type='time'],
 #backfill-dialog input[type='number'] {
-  width: min(100%, var(--bf-input-w));
-  max-width: var(--bf-input-w);
   background: var(--bf-input);
   color: var(--bf-text);
   border: 1px solid var(--bf-border);
@@ -6370,10 +6397,17 @@ body.modal-open #bf-batchbar {
   -webkit-backdrop-filter: none !important;
 }
 
+#backfill-batch-dialog input[type='date'] {
+  width: 160px;
+  max-width: 160px;
+}
+#backfill-batch-dialog input[type='time'] {
+  width: 120px;
+  max-width: 120px;
+}
 #backfill-batch-dialog input[type='date'],
+#backfill-batch-dialog input[type='time'],
 #backfill-batch-dialog input[type='number'] {
-  width: min(100%, var(--bf-input-w));
-  max-width: var(--bf-input-w);
   background: var(--bf-input);
   color: var(--bf-text);
   border: 1px solid var(--bf-border);
@@ -6446,20 +6480,36 @@ body.modal-open #bf-batchbar {
 }
 
 #backfill-batch-dialog label.radio {
-  margin: 18px 0;
+  margin: 8px 0;
   display: flex;
   align-items: center;
 }
 #backfill-batch-dialog label.radio > input[type='radio'] {
   margin-right: 8px;
 }
+#backfill-batch-dialog .checkbox-label {
+  margin: 8px 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+#backfill-batch-dialog .checkbox-label input[type="checkbox"] {
+  margin: 0;
+}
 
 #backfill-batch-dialog .bf-field .indent {
   margin: 6px 0 10px 1.75rem;
 }
 
-.bf-field .radio.has-tip .info-dot {
+.bf-field .radio.has-tip .info-dot,
+.bf-field .checkbox-label.has-tip .info-dot {
   margin-left: 2px;
+}
+.bf-field .tip-bubble {
+  white-space: normal;
+  word-break: break-word;
+  overflow-x: hidden;
+  max-width: min(340px, calc(100vw - 32px));
 }
 
 .side-menu .menu-list li a {

--- a/code/admin/templates/channels.html
+++ b/code/admin/templates/channels.html
@@ -258,21 +258,24 @@
               <input type="radio" name="mode" value="since">
               Since date/time
             </label>
-            <div class="indent">
+            <div class="indent bf-date-time-row">
               <input class="input" type="date" id="bf-since" name="since" disabled>
+              <input class="input bf-time" type="time" id="bf-since-time" disabled placeholder="00:00">
             </div>
             <label class="radio">
               <input type="radio" name="mode" value="between">
               Between dates
             </label>
             <div class="indent bf-row-between">
-              <div class="bf-dual">
+              <div class="bf-dual bf-date-time-row">
                 <label class="sr-only" for="bf-from">From</label>
                 <input class="input" type="date" id="bf-from" disabled>
+                <input class="input bf-time" type="time" id="bf-from-time" disabled>
               </div>
-              <div class="bf-dual" style="margin-top:8px">
+              <div class="bf-dual bf-date-time-row" style="margin-top:8px">
                 <label class="sr-only" for="bf-to">To</label>
                 <input class="input" type="date" id="bf-to" disabled>
+                <input class="input bf-time" type="time" id="bf-to-time" disabled>
               </div>
             </div>
             <label class="radio">
@@ -284,6 +287,17 @@
             </div>
           </fieldset>
 
+          <fieldset class="field bf-field" style="margin-top:12px">
+            <legend>Settings</legend>
+            <label class="checkbox-label has-tip">
+              <input type="checkbox" id="bf-ignore-cloned" name="ignore_cloned">
+              <span>Ignore cloned messages</span>
+              <button class="info-dot" type="button" aria-describedby="tip-bf-ignore"></button>
+              <div id="tip-bf-ignore" class="tip-bubble" role="tooltip" aria-hidden="true">
+                Filters out already-cloned messages using the local DB. Disable DB_CLEANUP_MSG in mapping settings to keep records intact.
+              </div>
+            </label>
+          </fieldset>
 
           <div class="buttons">
             <button type="submit" id="bf-start" class="btn btn-ghost">Start</button>

--- a/code/client/client.py
+++ b/code/client/client.py
@@ -266,6 +266,8 @@ class ClientListener:
             resume = bool(data.get("resume"))
             after_id = data.get("after_id")
 
+            exclude_ids = data.get("exclude_ids")
+
             params = {
                 "after_iso": after_iso,
                 "before_iso": before_iso,
@@ -275,6 +277,7 @@ class ClientListener:
                 "mapping_id": data.get("mapping_id"),
                 "cloned_guild_id": data.get("cloned_guild_id"),
                 "original_guild_id": data.get("original_guild_id"),
+                **({"exclude_ids": exclude_ids} if exclude_ids else {}),
             }
             return await self._enqueue_backfill(chan_id, params)
 

--- a/code/client/export_runners.py
+++ b/code/client/export_runners.py
@@ -1335,6 +1335,7 @@ class BackfillEngine:
         mapping_id: str | None = None,
         original_guild_id: int | None = None,
         cloned_guild_id: int | None = None,
+        exclude_ids: list | None = None,
     ):
         """
         Primary entry point used by client code to backfill a single channel.
@@ -1371,12 +1372,13 @@ class BackfillEngine:
         )
 
         self.logger.info(
-            "[backfill] ▶ START requested | channel_id=%s mode=%s after=%r before=%r last_n=%r — large channels can take a while to pull history",
+            "[backfill] ▶ START requested | channel_id=%s mode=%s after=%r before=%r last_n=%r exclude=%d — large channels can take a while to pull history",
             original_channel_id,
             mode,
             after_iso,
             before_iso,
             last_n,
+            len(exclude_ids or []),
         )
 
         self.logger.debug(
@@ -1509,8 +1511,15 @@ class BackfillEngine:
                 before_iso,
             )
 
+        _exclude_set = set(str(x) for x in (exclude_ids or []))
+        excluded = 0
+
         async def _emit_msg(m):
-            nonlocal sent, skipped, last_ping, last_log
+            nonlocal sent, skipped, excluded, last_ping, last_log
+
+            if _exclude_set and str(getattr(m, "id", None)) in _exclude_set:
+                excluded += 1
+                return
 
             if not _is_normal(m):
                 skipped += 1
@@ -2059,12 +2068,13 @@ class BackfillEngine:
                 pass
 
             dur = loop.time() - t0
-            self.logger.debug(
-                "[backfill] STREAM END | channel=%s mode=%s sent=%d skipped=%d dur=%.1fs",
+            self.logger.info(
+                "[backfill] ✅ DONE | channel=%s mode=%s sent=%d skipped=%d excluded=%d dur=%.1fs",
                 original_channel_id,
                 mode,
                 sent,
                 skipped,
+                excluded,
                 dur,
             )
             await self._safe_ws_send(

--- a/code/common/db.py
+++ b/code/common/db.py
@@ -2445,6 +2445,20 @@ class DBManager:
             (int(original_message_id), int(cloned_guild_id)),
         ).fetchone()
 
+    def get_cloned_original_ids_for_channel(
+        self, original_channel_id: int, cloned_guild_id: int
+    ) -> list[int]:
+        """
+        Return all original_message_id values that have already been cloned
+        for the given original channel into the given clone guild.
+        """
+        rows = self.conn.execute(
+            "SELECT original_message_id FROM messages "
+            "WHERE original_channel_id = ? AND cloned_guild_id = ?",
+            (int(original_channel_id), int(cloned_guild_id)),
+        ).fetchall()
+        return [r["original_message_id"] if isinstance(r, dict) else r[0] for r in rows]
+
     def delete_old_messages(
         self,
         older_than_seconds: int = 7 * 24 * 3600,

--- a/website/docs/dashboard/backfill.md
+++ b/website/docs/dashboard/backfill.md
@@ -5,14 +5,63 @@ title: History Import (Backfill)
 
 # History Import (Backfill)
 
-Copycord's backfill feature lets you import historical messages from source channels — not just new ones sent after setup.
+Copycord's backfill feature lets you import historical messages from source channels — not just new ones sent after setup. You can backfill a single channel or multiple channels at once using the batch backfill.
 
 ## Starting a backfill
 
-1. Navigate to the **Dashboard** or **Channels** page
+1. Navigate to the **Channels** page
 2. Select the channel(s) you want to backfill
-3. Click **Start Backfill** (single channel) or **Batch Backfill** (multiple channels)
-4. The import will begin processing in the background
+3. Click **Clone** (single channel) or select multiple channels and click **Batch Backfill**
+4. Configure the backfill options in the popup dialog
+5. Click **Start** — the import will begin processing in the background
+
+### Single channel backfill
+
+Click the clone button on any individual channel card to open the backfill dialog for that specific channel.
+
+### Batch backfill
+
+Select multiple channels by clicking their cards (they'll highlight when selected), then click the batch action button. The batch dialog lets you configure one set of options that apply to all selected channels at once.
+
+## Range options
+
+When starting a backfill, you can choose how far back to import:
+
+| Option | Description |
+|--------|-------------|
+| **All history** | Import the entire message history of the channel from the very beginning |
+| **Since date/time** | Import messages sent after a specific date and time |
+| **Between dates** | Import messages within a specific date and time range (from/to) |
+| **Last N messages** | Import only the most recent N messages |
+
+The **Since** and **Between** options support both date-only and date-with-time selection. If you only pick a date without a time, it defaults to the start of that day (midnight). If you select a specific time, the backfill will use the exact timestamp.
+
+:::tip Date range for Between mode
+When using **Between dates** with date-only values, the "To" date is inclusive — the range extends through the end of that day. When a specific time is selected, the exact timestamp is used as the cutoff.
+:::
+
+## Backfill mode (batch only)
+
+The batch backfill dialog includes a **Mode** selector:
+
+| Mode | Description |
+|------|-------------|
+| **Resume previous** | Resumes any in-progress backfill runs. If no previous run exists for a channel, a fresh run is started automatically |
+| **Start new** | Discards any in-progress runs and begins fresh backfills for all selected channels |
+
+## Settings
+
+### Ignore cloned messages
+
+When enabled, the backfill will skip messages that have already been cloned to the target server. Before starting the backfill, Copycord checks its local database for existing cloned message records and filters out any original message IDs that already have a clone. The server only receives the remaining uncloned messages.
+
+This is useful when:
+- You need to re-run a backfill but don't want to duplicate messages that were already cloned
+- A previous backfill was partially completed and you want to fill in the gaps without duplicates
+
+:::caution DB_CLEANUP_MSG and message records
+This feature relies on cloned message records stored in the database. If `DB_CLEANUP_MSG` is enabled in your [mapping settings](/docs/configuration/cloning-options#database-maintenance), old message records are periodically purged — which means previously cloned messages may no longer be detected. Consider disabling `DB_CLEANUP_MSG` for mappings where you plan to use this feature, so that message records are retained.
+:::
 
 ## How it works
 
@@ -35,7 +84,9 @@ The dashboard shows:
 
 ## Resuming interrupted backfills
 
-If a backfill is interrupted (e.g., bot restart), you can resume it from where it left off. The dashboard shows resume information for incomplete backfills.
+If a backfill is interrupted (e.g., bot restart, network issue), you can resume it from where it left off. The dashboard shows resume information for incomplete backfills, including the last checkpoint and number of messages delivered.
+
+For single channel backfills, Copycord will automatically prompt you to resume if an incomplete run is detected. For batch backfills, select **Resume previous** in the Mode selector.
 
 ## Limits and considerations
 


### PR DESCRIPTION
## Summary
- Add optional time inputs alongside date pickers for Since and Between backfill modes (date is required, time is optional — defaults to 00:00)
- Add "Ignore cloned messages" toggle to both single and batch backfill modals — filters out messages already cloned by checking the local DB before sending to the client agent
- Pass `exclude_ids` through the full pipeline: admin backend → WebSocket → client agent → export runner, where messages are skipped in `_emit_msg`
- Backfill completion log now shows `excluded` count separately from `skipped`
- Update backfill documentation with comprehensive coverage of all range options, settings, and the new ignore cloned feature

## Changes
- **Frontend**: Split `datetime-local` inputs into separate `date` + `time` inputs, update helper functions (`startOfDayIsoLocal`, `nextDayStartIsoLocal`), add checkbox UI and wiring for `ignore_cloned` flag
- **Backend** (`app.py`): Query `get_cloned_original_ids_for_channel()` when `ignore_cloned` is set, pass `exclude_ids` to client agent
- **Client** (`client.py`): Extract and forward `exclude_ids` from WebSocket command data
- **Export runner** (`export_runners.py`): Accept `exclude_ids` param, filter messages in `_emit_msg`, track `excluded` count separately
- **DB** (`db.py`): New `get_cloned_original_ids_for_channel()` method
- **Docs** (`backfill.md`): Expanded documentation covering range options, batch mode, settings, and DB_CLEANUP_MSG considerations