### PR TITLE
Fast sync, on-demand webhooks, auto-start, and event logs overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Copycord is the ultimate Discord server mirroring tool. Effortlessly clone multi
 ```yaml
 services:
   admin:
-    image: ghcr.io/copycord/copycord:v3.19.0
+    image: ghcr.io/copycord/copycord:v3.20.0
     container_name: copycord-admin
     environment:
       - ROLE=admin
@@ -111,7 +111,7 @@ services:
     restart: unless-stopped
 
   server:
-    image: ghcr.io/copycord/copycord:v3.19.0
+    image: ghcr.io/copycord/copycord:v3.20.0
     container_name: copycord-server
     environment:
       - ROLE=server
@@ -122,7 +122,7 @@ services:
     restart: unless-stopped
 
   client:
-    image: ghcr.io/copycord/copycord:v3.19.0
+    image: ghcr.io/copycord/copycord:v3.20.0
     container_name: copycord-client
     environment:
       - ROLE=client

--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -195,6 +195,8 @@ ALLOWED_ENV = [
     "CLIENT_TOKEN",
     "COMMAND_USERS",
     "LOG_LEVEL",
+    "COPYCORD_AUTOSTART",
+    "LOG_MAX_SIZE_MB",
 ]
 
 REQUIRED = ["SERVER_TOKEN", "CLIENT_TOKEN"]
@@ -202,6 +204,7 @@ REQUIRED = ["SERVER_TOKEN", "CLIENT_TOKEN"]
 BOOL_KEYS = [
     "ENABLE_CLONING",
     "CLONE_MESSAGES",
+    "ON_DEMAND_WEBHOOKS",
     "DELETE_CHANNELS",
     "DELETE_THREADS",
     "DELETE_MESSAGES",
@@ -276,6 +279,9 @@ DEFAULTS: Dict[str, Union[bool, str]] = {
     "DISABLE_ROLE_MENTIONS": False,
     "TAG_REPLY_MSG": False,
     "DB_CLEANUP_MSG": True,
+    "ON_DEMAND_WEBHOOKS": True,
+    "COPYCORD_AUTOSTART": "false",
+    "LOG_MAX_SIZE_MB": "10",
 }
 
 app = FastAPI(title=APP_TITLE)
@@ -1447,7 +1453,7 @@ async def index(request: Request):
 
     both_running = bool(s_server.get("running")) and bool(s_client.get("running"))
 
-    text_keys = [k for k in ALLOWED_ENV if k != "LOG_LEVEL"]
+    text_keys = [k for k in ALLOWED_ENV if k not in ("LOG_LEVEL", "COPYCORD_AUTOSTART", "LOG_MAX_SIZE_MB")]
 
     bool_keys = BOOL_KEYS
     guild_mappings = db.list_guild_mappings()
@@ -1695,6 +1701,28 @@ async def clear_logs():
     return RedirectResponse("/", status_code=303)
 
 
+@app.post("/logs/clear/{which}")
+async def clear_logs_which(which: str):
+    if which == "server":
+        names = ("server.log", "server.out")
+    elif which == "client":
+        names = ("client.log", "client.out")
+    else:
+        return PlainTextResponse("invalid", status_code=400)
+    cleared = []
+    for name in names:
+        p = DATA_DIR / name
+        try:
+            if p.exists():
+                with open(p, "w", encoding="utf-8"):
+                    pass
+                cleared.append(name)
+        except Exception:
+            pass
+    LOGGER.info("POST /logs/clear/%s done | cleared=%s", which, cleared)
+    return PlainTextResponse("ok")
+
+
 @app.get("/logs/{which}", response_class=PlainTextResponse)
 async def logs(which: str, tail: int = 20000):
     if which == "server":
@@ -1783,6 +1811,57 @@ async def _start_bg_tasks():
 
 
 @app.on_event("startup")
+async def _maybe_autostart():
+    asyncio.create_task(_autostart_if_ready())
+
+
+async def _autostart_if_ready():
+    """Auto-start server and client if enabled, tokens are valid, and mappings exist."""
+    await asyncio.sleep(5)  # wait for controllers to boot
+
+    try:
+        autostart = db.get_config("COPYCORD_AUTOSTART", "false")
+        if autostart.lower() not in ("1", "true", "yes", "on"):
+            return
+
+        env = _read_env()
+        server_token = (env.get("SERVER_TOKEN") or "").strip()
+        client_token = (env.get("CLIENT_TOKEN") or "").strip()
+        if not server_token or not client_token:
+            LOGGER.info("Auto-start skipped: missing tokens")
+            return
+
+        token_errs = await _verify_tokens_for_save(
+            {"CLIENT_TOKEN": client_token, "SERVER_TOKEN": server_token}
+        )
+        if token_errs:
+            LOGGER.info("Auto-start skipped: invalid tokens (%s)", "; ".join(token_errs))
+            return
+
+        srv_ok, srv_reason, _ = await _check_controller("Server", SERVER_CTRL_URL)
+        cli_ok, cli_reason, _ = await _check_controller("Client", CLIENT_CTRL_URL)
+        if not srv_ok or not cli_ok:
+            reasons = []
+            if not srv_ok:
+                reasons.append(f"Server: {srv_reason}")
+            if not cli_ok:
+                reasons.append(f"Client: {cli_reason}")
+            LOGGER.info("Auto-start skipped: controllers not reachable (%s)", "; ".join(reasons))
+            return
+
+        srv = await _ws_cmd(SERVER_CTRL_URL, {"cmd": "start"})
+        cli = await _ws_cmd(CLIENT_CTRL_URL, {"cmd": "start"})
+
+        LOGGER.info(
+            "Auto-start complete: server=%s, client=%s",
+            srv.get("status", "unknown"),
+            cli.get("status", "unknown"),
+        )
+    except Exception:
+        LOGGER.exception("Auto-start failed")
+
+
+@app.on_event("startup")
 async def _start_release_watcher():
     asyncio.create_task(_release_watch_loop())
 
@@ -1790,6 +1869,56 @@ async def _start_release_watcher():
 @app.on_event("startup")
 async def _start_backup_scheduler():
     backup_scheduler.start()
+
+
+@app.on_event("startup")
+async def _start_log_pruner():
+    asyncio.create_task(_log_prune_loop())
+
+
+async def _log_prune_loop():
+    """Periodically check log file sizes and truncate to the configured max."""
+    LOG_FILES = [
+        ("server.log", "server.out"),
+        ("client.log", "client.out"),
+    ]
+    LOGGER.info("Log pruning task started (checks every 5 minutes)")
+    while True:
+        await asyncio.sleep(300)  # check every 5 minutes
+        try:
+            max_mb_str = db.get_config("LOG_MAX_SIZE_MB", "10")
+            max_bytes = int(max_mb_str) * 1024 * 1024
+            if max_bytes <= 0:
+                continue
+
+            for names in LOG_FILES:
+                for name in names:
+                    p = DATA_DIR / name
+                    try:
+                        if not p.exists():
+                            continue
+                        size = p.stat().st_size
+                        if size <= max_bytes:
+                            continue
+
+                        # Keep the last max_bytes worth of content
+                        text = p.read_text(encoding="utf-8", errors="ignore")
+                        trimmed = text[-max_bytes:]
+                        # Cut at the first newline to avoid partial lines
+                        nl = trimmed.find("\n")
+                        if nl != -1:
+                            trimmed = trimmed[nl + 1:]
+                        p.write_text(trimmed, encoding="utf-8")
+                        LOGGER.info(
+                            "Pruned %s: %.1fMB → %.1fMB",
+                            name,
+                            size / (1024 * 1024),
+                            len(trimmed.encode("utf-8")) / (1024 * 1024),
+                        )
+                    except Exception:
+                        LOGGER.debug("Log prune failed for %s", name, exc_info=True)
+        except Exception:
+            LOGGER.debug("Log prune loop error", exc_info=True)
 
 
 @app.on_event("startup")
@@ -2862,6 +2991,14 @@ def _write_env(values: Dict[str, str]) -> None:
             v = _norm_bool_str(v)
         if k == "LOG_LEVEL":
             v = "DEBUG" if str(v).upper() == "DEBUG" else "INFO"
+        if k == "COPYCORD_AUTOSTART":
+            v = "true" if str(v).lower() in ("1", "true", "yes", "on") else "false"
+            os.environ["COPYCORD_AUTOSTART"] = v
+        if k == "LOG_MAX_SIZE_MB":
+            try:
+                v = str(max(0, int(v)))
+            except (ValueError, TypeError):
+                v = "10"
         db.set_config(k, v)
     LOGGER.info("Config saved | %s", _redact_dict(values))
 
@@ -2888,13 +3025,6 @@ def _validate(values: Dict[str, str], *, for_start: bool = False) -> List[str]:
                 errs.append("HOST_GUILD_ID must be a positive integer")
         except Exception:
             errs.append("HOST_GUILD_ID must be an integer")
-
-    if not errs and for_start:
-        try:
-            if len(db.list_guild_mappings()) == 0:
-                errs.append("At least one guild_mapping is required")
-        except Exception:
-            errs.append("At least one guild_mapping is required")
 
     if errs:
         LOGGER.warning("Config validation failed | errs=%s", errs)

--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -1884,46 +1884,55 @@ async def _start_log_pruner():
 
 
 async def _log_prune_loop():
-    """Periodically check log file sizes and truncate to the configured max."""
-    LOG_FILES = [
-        ("server.log", "server.out"),
-        ("client.log", "client.out"),
-    ]
+    """Periodically check log file sizes and truncate to the configured max.
+
+    Uses seek-based reading so only the tail is loaded into memory,
+    even if the file is hundreds of MB.
+    """
+    LOG_FILES = ("server.out", "client.out")
     LOGGER.info("Log pruning task started (checks every 5 minutes)")
     while True:
-        await asyncio.sleep(300)  # check every 5 minutes
+        await asyncio.sleep(300)
         try:
             max_mb_str = db.get_config("LOG_MAX_SIZE_MB", "10")
             max_bytes = int(max_mb_str) * 1024 * 1024
             if max_bytes <= 0:
                 continue
 
-            for names in LOG_FILES:
-                for name in names:
-                    p = DATA_DIR / name
-                    try:
-                        if not p.exists():
-                            continue
-                        size = p.stat().st_size
-                        if size <= max_bytes:
-                            continue
+            for name in LOG_FILES:
+                p = DATA_DIR / name
+                try:
+                    if not p.exists():
+                        continue
+                    size = p.stat().st_size
+                    if size <= max_bytes:
+                        continue
 
-                        # Keep the last max_bytes worth of content
-                        text = p.read_text(encoding="utf-8", errors="ignore")
-                        trimmed = text[-max_bytes:]
-                        # Cut at the first newline to avoid partial lines
-                        nl = trimmed.find("\n")
-                        if nl != -1:
-                            trimmed = trimmed[nl + 1:]
-                        p.write_text(trimmed, encoding="utf-8")
-                        LOGGER.info(
-                            "Pruned %s: %.1fMB → %.1fMB",
-                            name,
-                            size / (1024 * 1024),
-                            len(trimmed.encode("utf-8")) / (1024 * 1024),
-                        )
-                    except Exception:
-                        LOGGER.debug("Log prune failed for %s", name, exc_info=True)
+                    # Only read the tail we want to keep
+                    with open(p, "rb") as f:
+                        f.seek(size - max_bytes)
+                        tail = f.read()
+
+                    # Decode and cut at the first newline to avoid a partial line
+                    text = tail.decode("utf-8", errors="ignore")
+                    nl = text.find("\n")
+                    if nl != -1:
+                        text = text[nl + 1:]
+
+                    # Write back atomically via temp file
+                    tmp = p.with_suffix(".tmp")
+                    tmp.write_text(text, encoding="utf-8")
+                    tmp.replace(p)
+
+                    new_size = p.stat().st_size
+                    LOGGER.info(
+                        "Pruned %s: %.1fMB -> %.1fMB",
+                        name,
+                        size / (1024 * 1024),
+                        new_size / (1024 * 1024),
+                    )
+                except Exception:
+                    LOGGER.debug("Log prune failed for %s", name, exc_info=True)
         except Exception:
             LOGGER.debug("Log prune loop error", exc_info=True)
 

--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -1817,7 +1817,7 @@ async def _maybe_autostart():
 
 async def _autostart_if_ready():
     """Auto-start server and client if enabled, tokens are valid, and mappings exist."""
-    await asyncio.sleep(5)  # wait for controllers to boot
+    await asyncio.sleep(1)
 
     try:
         autostart = db.get_config("COPYCORD_AUTOSTART", "false")
@@ -1857,6 +1857,13 @@ async def _autostart_if_ready():
             srv.get("status", "unknown"),
             cli.get("status", "unknown"),
         )
+
+        for role in ("server", "client"):
+            await hub.broadcast({
+                "type": "status",
+                "source": role,
+                "data": {"running": True},
+            })
     except Exception:
         LOGGER.exception("Auto-start failed")
 

--- a/code/admin/frontend/src/js/app.js
+++ b/code/admin/frontend/src/js/app.js
@@ -4581,6 +4581,7 @@
           };
           if (source === "server") renderStatusRow("server", common);
           if (source === "client") renderStatusRow("client", common);
+          fetchAndRenderStatus();
         }
         if (msg.kind === "agent" && msg.type === "status") {
           const prefix = msg.role === "server" ? "server" : "client";

--- a/code/admin/frontend/src/js/app.js
+++ b/code/admin/frontend/src/js/app.js
@@ -215,6 +215,7 @@
     DISABLE_ROLE_MENTIONS: false,
     TAG_REPLY_MSG: false,
     DB_CLEANUP_MSG: true,
+    ON_DEMAND_WEBHOOKS: true,
   };
 
   let lastFocusLog = null;
@@ -848,8 +849,11 @@
     renderLogView({ preserveScroll: true });
   }
 
+  let currentLogType = null;
+
   function openLogs(which) {
     if (!modal || !logBody) return;
+    currentLogType = which;
     if (es) {
       try {
         es.close();
@@ -979,6 +983,34 @@
     if (e.key === "Escape" && modal && modal.classList.contains("show"))
       closeLogs();
   });
+
+  const logClearBtn = document.getElementById("log-clear-btn");
+  if (logClearBtn) {
+    logClearBtn.addEventListener("click", () => {
+      if (!currentLogType) return;
+      const label = currentLogType === "server" ? "Server" : "Client";
+      openConfirm({
+        title: "Clear logs?",
+        body: `This will permanently delete all ${label.toLowerCase()} logs. This cannot be undone.`,
+        confirmText: "Clear logs",
+        confirmClass: "btn-ghost-red",
+        onConfirm: async () => {
+          try {
+            const resp = await fetch(`/logs/clear/${currentLogType}`, { method: "POST" });
+            if (resp.ok) {
+              LOG_LINES = [];
+              renderLogView();
+              showToast(`${label} logs cleared`, { type: "success", timeout: 2000 });
+            } else {
+              showToast("Failed to clear logs", { type: "error" });
+            }
+          } catch {
+            showToast("Failed to clear logs", { type: "error" });
+          }
+        },
+      });
+    });
+  }
 
   function enhanceAllSelects() {
     document
@@ -1745,15 +1777,12 @@
     const vals = Object.fromEntries(REQUIRED_KEYS.map((k) => [k, get(k)]));
 
     const hasTokens = !!(vals.SERVER_TOKEN && vals.CLIENT_TOKEN);
-    const hasAtLeastOneMapping =
-      Array.isArray(GUILD_MAPPINGS) && GUILD_MAPPINGS.length > 0;
 
-    const ok = hasTokens && hasAtLeastOneMapping;
+    const ok = hasTokens;
 
     const missing = [];
     if (!vals.SERVER_TOKEN) missing.push("SERVER_TOKEN");
     if (!vals.CLIENT_TOKEN) missing.push("CLIENT_TOKEN");
-    if (!hasAtLeastOneMapping) missing.push("GUILD_MAPPINGS");
 
     return { ok, missing };
   }
@@ -1878,7 +1907,7 @@
         "Saved tokens are no longer valid. Please update SERVER_TOKEN and CLIENT_TOKEN to start.";
     } else if (!ok) {
       btn.title =
-        "Provide SERVER_TOKEN, CLIENT_TOKEN, and at least one Guild Mapping to start.";
+        "Provide SERVER_TOKEN and CLIENT_TOKEN to start.";
     } else {
       btn.title = "";
     }
@@ -4904,7 +4933,7 @@
         "Saved tokens are no longer valid. Please update SERVER_TOKEN and CLIENT_TOKEN to start.";
     } else if (!ok) {
       btn.title =
-        "Provide SERVER_TOKEN, CLIENT_TOKEN, and at least one Guild Mapping to start.";
+        "Provide SERVER_TOKEN and CLIENT_TOKEN to start.";
     } else {
       btn.title = "";
     }

--- a/code/admin/frontend/src/js/logs.js
+++ b/code/admin/frontend/src/js/logs.js
@@ -2,7 +2,9 @@
   const root = document.getElementById("logs-root");
   if (!root) return;
 
-  let allLogs = [];
+  const PAGE_SIZE = 50;
+  let currentPage = 1;
+  let totalLogs = 0;
   let currentType = "";
   let currentSearch = "";
   let sortColumn = "created_at";
@@ -16,6 +18,7 @@
   const searchEl = document.getElementById("logs-search");
   const clearAllBtn = document.getElementById("logs-clear-all");
   const clearFiltersBtn = document.getElementById("logs-clear-filters");
+  const paginationEl = document.getElementById("logs-pagination");
 
   function blurActive() {
     const ae = document.activeElement;
@@ -226,63 +229,59 @@
       .replace(/"/g, "&quot;");
   }
 
-  function getFilteredSorted() {
-    let filtered = allLogs;
-
-    if (currentType) {
-      filtered = filtered.filter((l) => l.event_type === currentType);
-    }
-    if (currentSearch) {
-      const q = currentSearch.toLowerCase();
-      filtered = filtered.filter(
-        (l) =>
-          (l.details || "").toLowerCase().includes(q) ||
-          (l.guild_name || "").toLowerCase().includes(q) ||
-          (l.channel_name || "").toLowerCase().includes(q) ||
-          (l.event_type || "").toLowerCase().includes(q)
-      );
-    }
-
-    filtered.sort((a, b) => {
-      let va = a[sortColumn];
-      let vb = b[sortColumn];
-
-      if (va == null) va = "";
-      if (vb == null) vb = "";
-
-      if (typeof va === "string") va = va.toLowerCase();
-      if (typeof vb === "string") vb = vb.toLowerCase();
-
-      let cmp = 0;
-      if (va < vb) cmp = -1;
-      else if (va > vb) cmp = 1;
-
-      return sortDir === "asc" ? cmp : -cmp;
-    });
-
-    return filtered;
+  function buildQueryParams() {
+    const params = new URLSearchParams();
+    params.set("limit", PAGE_SIZE);
+    params.set("offset", (currentPage - 1) * PAGE_SIZE);
+    if (currentType) params.set("event_type", currentType);
+    if (currentSearch) params.set("search", currentSearch);
+    return params.toString();
   }
 
-  function renderAll() {
-    const logs = getFilteredSorted();
-    tbody.innerHTML = "";
+  function renderPagination() {
+    if (!paginationEl) return;
+    const totalPages = Math.max(1, Math.ceil(totalLogs / PAGE_SIZE));
 
-    if (logs.length === 0) {
-      emptyEl.style.display = "";
-      countEl.textContent = "";
-    } else {
-      emptyEl.style.display = "none";
-      countEl.textContent = `Showing ${logs.length} of ${allLogs.length} logs`;
-      const frag = document.createDocumentFragment();
-      logs.forEach((log) => frag.appendChild(renderRow(log)));
-      tbody.appendChild(frag);
+    if (totalPages <= 1) {
+      paginationEl.innerHTML = "";
+      return;
     }
-    updateClearFilters();
+
+    const btns = [];
+
+    btns.push(
+      `<button class="pg-btn" data-page="${currentPage - 1}" ${currentPage <= 1 ? "disabled" : ""} aria-label="Previous page">&laquo;</button>`
+    );
+
+    const range = [];
+    range.push(1);
+    for (let i = Math.max(2, currentPage - 2); i <= Math.min(totalPages - 1, currentPage + 2); i++) {
+      range.push(i);
+    }
+    if (totalPages > 1) range.push(totalPages);
+
+    const unique = [...new Set(range)].sort((a, b) => a - b);
+    let last = 0;
+    for (const p of unique) {
+      if (last && p - last > 1) {
+        btns.push(`<span class="pg-ellipsis">&hellip;</span>`);
+      }
+      btns.push(
+        `<button class="pg-btn${p === currentPage ? " pg-active" : ""}" data-page="${p}">${p}</button>`
+      );
+      last = p;
+    }
+
+    btns.push(
+      `<button class="pg-btn" data-page="${currentPage + 1}" ${currentPage >= totalPages ? "disabled" : ""} aria-label="Next page">&raquo;</button>`
+    );
+
+    paginationEl.innerHTML = btns.join("");
   }
 
   async function loadLogs() {
     try {
-      const res = await fetch("/api/event-logs?limit=10000&offset=0", {
+      const res = await fetch(`/api/event-logs?${buildQueryParams()}`, {
         credentials: "same-origin",
         cache: "no-store",
         headers: { "Cache-Control": "no-cache" },
@@ -290,8 +289,27 @@
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
 
-      allLogs = data.logs || [];
-      renderAll();
+      totalLogs = data.total || 0;
+      const logs = data.logs || [];
+
+      tbody.innerHTML = "";
+      if (logs.length === 0) {
+        emptyEl.style.display = "";
+        countEl.textContent = totalLogs > 0
+          ? `No results for current filters (${totalLogs} total)`
+          : "";
+      } else {
+        emptyEl.style.display = "none";
+        const start = (currentPage - 1) * PAGE_SIZE + 1;
+        const end = start + logs.length - 1;
+        countEl.textContent = `Showing ${start}-${end} of ${totalLogs}`;
+        const frag = document.createDocumentFragment();
+        logs.forEach((log) => frag.appendChild(renderRow(log)));
+        tbody.appendChild(frag);
+      }
+
+      renderPagination();
+      updateClearFilters();
     } catch (err) {
       console.error("Failed to load event logs:", err);
     }
@@ -338,21 +356,24 @@
           arrow.textContent = "";
         }
       });
-      renderAll();
+      currentPage = 1;
+      loadLogs();
     });
   });
 
   filterEl.addEventListener("change", () => {
     currentType = filterEl.value;
-    renderAll();
+    currentPage = 1;
+    loadLogs();
   });
 
   searchEl.addEventListener("input", () => {
     clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
       currentSearch = searchEl.value.trim();
-      renderAll();
-    }, 200);
+      currentPage = 1;
+      loadLogs();
+    }, 300);
   });
 
   clearFiltersBtn.addEventListener("click", () => {
@@ -361,8 +382,22 @@
     searchEl.value = "";
     filterEl.value = "";
     filterEl.dispatchEvent(new Event("change", { bubbles: true }));
-    renderAll();
+    currentPage = 1;
+    loadLogs();
   });
+
+  if (paginationEl) {
+    paginationEl.addEventListener("click", (e) => {
+      const btn = e.target.closest("[data-page]");
+      if (!btn || btn.disabled) return;
+      const page = parseInt(btn.dataset.page, 10);
+      if (page >= 1 && page <= Math.ceil(totalLogs / PAGE_SIZE)) {
+        currentPage = page;
+        loadLogs();
+        root.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    });
+  }
 
   tbody.addEventListener("click", async (e) => {
     const btn = e.target.closest(".log-delete-btn");
@@ -377,25 +412,8 @@
         credentials: "same-origin",
       });
       if (res.ok) {
-        const row = tbody.querySelector(`tr[data-log-id="${logId}"]`);
-        if (row) {
-          row.classList.add("log-removing");
-          row.addEventListener(
-            "animationend",
-            () => {
-              row.remove();
-              allLogs = allLogs.filter((l) => l.log_id !== logId);
-              if (allLogs.length === 0) {
-                emptyEl.style.display = "";
-                countEl.textContent = "";
-              } else {
-                const visible = tbody.querySelectorAll("tr").length;
-                countEl.textContent = `Showing ${visible} of ${allLogs.length} logs`;
-              }
-            },
-            { once: true }
-          );
-        }
+        totalLogs = Math.max(0, totalLogs - 1);
+        loadLogs();
       }
     } catch (err) {
       console.error("Delete log failed:", err);
@@ -417,8 +435,9 @@
             credentials: "same-origin",
           });
           if (res.ok) {
-            allLogs = [];
-            renderAll();
+            totalLogs = 0;
+            currentPage = 1;
+            loadLogs();
             window.showToast?.("All logs cleared", { type: "success" });
           }
         } catch (err) {

--- a/code/admin/frontend/src/js/logs.js
+++ b/code/admin/frontend/src/js/logs.js
@@ -190,10 +190,89 @@
     }
   }
 
+  function parseExtra(log) {
+    if (!log.extra_json) return null;
+    try {
+      return typeof log.extra_json === "string" ? JSON.parse(log.extra_json) : log.extra_json;
+    } catch {
+      return null;
+    }
+  }
+
+  function hasMetadata(log) {
+    return !!(log.channel_id || log.channel_name || log.category_id || log.category_name || log.guild_id || parseExtra(log));
+  }
+
+  const EXTRA_LABELS = {
+    sync_task_id: "Sync Task",
+    original_channel_id: "Source Channel ID",
+    clone_channel_id: "Clone Channel ID",
+    original_category_id: "Source Category ID",
+    clone_category_id: "Clone Category ID",
+    original_role_id: "Source Role ID",
+    clone_role_id: "Clone Role ID",
+    original_emoji_id: "Source Emoji ID",
+    clone_emoji_id: "Clone Emoji ID",
+    original_sticker_id: "Source Sticker ID",
+    clone_sticker_id: "Clone Sticker ID",
+    original_thread_id: "Source Thread ID",
+    clone_thread_id: "Clone Thread ID",
+    clone_channel_id: "Clone Channel ID",
+    changed_fields: "Changed Fields",
+    changes: "Changes",
+  };
+
+  function buildMetadataHtml(log) {
+    const extra = parseExtra(log);
+    const rows = [];
+    const handled = new Set();
+
+    if (extra && extra.sync_task_id) {
+      rows.push(["Sync Task", extra.sync_task_id]);
+      handled.add("sync_task_id");
+    }
+    if (log.guild_id) rows.push(["Guild ID", log.guild_id]);
+    if (log.channel_name) rows.push(["Channel", log.channel_name]);
+    if (log.category_name) rows.push(["Category", log.category_name]);
+    if (log.category_id) rows.push(["Category ID", log.category_id]);
+
+    if (extra) {
+      const orderedKeys = [
+        "original_channel_id", "clone_channel_id",
+        "original_category_id", "clone_category_id",
+        "original_role_id", "clone_role_id",
+        "original_emoji_id", "clone_emoji_id",
+        "original_sticker_id", "clone_sticker_id",
+        "original_thread_id", "clone_thread_id",
+        "changed_fields", "changes",
+      ];
+      for (const k of orderedKeys) {
+        if (extra[k] != null) {
+          const val = Array.isArray(extra[k]) ? extra[k].join(", ") : extra[k];
+          rows.push([EXTRA_LABELS[k] || k, val]);
+          handled.add(k);
+        }
+      }
+      for (const [k, v] of Object.entries(extra)) {
+        if (handled.has(k)) continue;
+        const label = EXTRA_LABELS[k] || k.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+        const val = Array.isArray(v) ? v.join(", ") : v;
+        rows.push([label, val]);
+      }
+    }
+
+    if (!rows.length) return "";
+    return rows
+      .map(([label, val]) => `<div class="log-meta-item"><span class="log-meta-label">${esc(String(label))}</span><span class="log-meta-value">${esc(String(val))}</span></div>`)
+      .join("");
+  }
+
   function renderRow(log) {
     const meta = getMeta(log.event_type);
+    const frag = document.createDocumentFragment();
+
     const tr = document.createElement("tr");
-    tr.className = "log-row";
+    tr.className = "log-row" + (hasMetadata(log) ? " log-expandable" : "");
     tr.dataset.logId = log.log_id;
 
     const guildText =
@@ -217,7 +296,18 @@
       `<path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />` +
       `</svg></button></td>`;
 
-    return tr;
+    frag.appendChild(tr);
+
+    if (hasMetadata(log)) {
+      const detailTr = document.createElement("tr");
+      detailTr.className = "log-detail-row";
+      detailTr.dataset.detailFor = log.log_id;
+      detailTr.hidden = true;
+      detailTr.innerHTML = `<td colspan="5"><div class="log-meta-panel">${buildMetadataHtml(log)}</div></td>`;
+      frag.appendChild(detailTr);
+    }
+
+    return frag;
   }
 
   function esc(s) {
@@ -401,23 +491,35 @@
 
   tbody.addEventListener("click", async (e) => {
     const btn = e.target.closest(".log-delete-btn");
-    if (!btn) return;
-    const logId = btn.dataset.logId;
-    if (!logId) return;
-
-    btn.disabled = true;
-    try {
-      const res = await fetch(`/api/event-logs/${logId}`, {
-        method: "DELETE",
-        credentials: "same-origin",
-      });
-      if (res.ok) {
-        totalLogs = Math.max(0, totalLogs - 1);
-        loadLogs();
+    if (btn) {
+      const logId = btn.dataset.logId;
+      if (!logId) return;
+      btn.disabled = true;
+      try {
+        const res = await fetch(`/api/event-logs/${logId}`, {
+          method: "DELETE",
+          credentials: "same-origin",
+        });
+        if (res.ok) {
+          totalLogs = Math.max(0, totalLogs - 1);
+          loadLogs();
+        }
+      } catch (err) {
+        console.error("Delete log failed:", err);
+        btn.disabled = false;
       }
-    } catch (err) {
-      console.error("Delete log failed:", err);
-      btn.disabled = false;
+      return;
+    }
+
+    const row = e.target.closest("tr.log-expandable");
+    if (row) {
+      const logId = row.dataset.logId;
+      const detailRow = tbody.querySelector(`tr[data-detail-for="${logId}"]`);
+      if (detailRow) {
+        const isOpen = !detailRow.hidden;
+        detailRow.hidden = isOpen;
+        row.classList.toggle("log-expanded", !isOpen);
+      }
     }
   });
 

--- a/code/admin/frontend/src/js/logs.js
+++ b/code/admin/frontend/src/js/logs.js
@@ -17,6 +17,7 @@
   const filterEl = document.getElementById("logs-filter-type");
   const searchEl = document.getElementById("logs-search");
   const clearAllBtn = document.getElementById("logs-clear-all");
+  const refreshBtn = document.getElementById("logs-refresh");
   const clearFiltersBtn = document.getElementById("logs-clear-filters");
   const paginationEl = document.getElementById("logs-pagination");
 
@@ -400,26 +401,39 @@
 
       renderPagination();
       updateClearFilters();
+      populateFilterDropdown(data.types || []);
     } catch (err) {
       console.error("Failed to load event logs:", err);
     }
   }
 
-  function populateFilterDropdown() {
+  let rebuildingDropdown = false;
+
+  function populateFilterDropdown(activeTypes) {
+    rebuildingDropdown = true;
+    const prev = filterEl.value;
     while (filterEl.options.length > 1) filterEl.remove(1);
 
-    const sorted = Object.keys(TYPE_META).sort((a, b) => {
-      const la = TYPE_META[a].label.toLowerCase();
-      const lb = TYPE_META[b].label.toLowerCase();
-      return la < lb ? -1 : la > lb ? 1 : 0;
-    });
+    const sorted = activeTypes
+      .map((t) => ({ key: t, label: getMeta(t).label }))
+      .sort((a, b) => a.label.toLowerCase() < b.label.toLowerCase() ? -1 : 1);
 
-    sorted.forEach((t) => {
+    sorted.forEach(({ key, label }) => {
       const opt = document.createElement("option");
-      opt.value = t;
-      opt.textContent = TYPE_META[t].label;
+      opt.value = key;
+      opt.textContent = label;
       filterEl.appendChild(opt);
     });
+
+    if (prev && Array.from(filterEl.options).some(o => o.value === prev)) {
+      filterEl.value = prev;
+    } else {
+      filterEl.value = "";
+      currentType = "";
+    }
+    rebuildingDropdown = true;
+    filterEl.dispatchEvent(new Event("change", { bubbles: true }));
+    setTimeout(() => { rebuildingDropdown = false; }, 0);
   }
 
   function updateClearFilters() {
@@ -452,6 +466,7 @@
   });
 
   filterEl.addEventListener("change", () => {
+    if (rebuildingDropdown) return;
     currentType = filterEl.value;
     currentPage = 1;
     loadLogs();
@@ -523,6 +538,12 @@
     }
   });
 
+  if (refreshBtn) {
+    refreshBtn.addEventListener("click", () => {
+      loadLogs();
+    });
+  }
+
   clearAllBtn.addEventListener("click", () => {
     openConfirm({
       title: "Delete All Logs",
@@ -551,6 +572,5 @@
     });
   });
 
-  populateFilterDropdown();
   loadLogs();
 })();

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -11403,6 +11403,44 @@ body.page-forwarding .fwd-no-match-sub {
   color: rgba(255, 255, 255, 0.8);
   font-size: 13px;
 }
+tr.log-expandable {
+  cursor: pointer;
+}
+tr.log-expandable:hover td {
+  background: rgba(139, 92, 246, 0.06);
+}
+tr.log-expanded td {
+  border-bottom-color: transparent;
+}
+.log-detail-row td {
+  padding: 0 !important;
+  border-top: none !important;
+}
+.log-meta-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px 24px;
+  padding: 12px 20px 16px;
+  background: rgba(15, 8, 30, 0.5);
+  border-bottom: 1px solid var(--border);
+}
+.log-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.log-meta-label {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.log-meta-value {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.85);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  word-break: break-all;
+}
 
 /* ── Type badge ──────────────────────────────────────────── */
 .log-type-badge {

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -11313,7 +11313,8 @@ body.page-forwarding .fwd-no-match-sub {
   border: 1px solid var(--border);
   background: linear-gradient(180deg, rgba(27, 16, 48, 0.5) 0%, rgba(15, 8, 30, 0.6) 100%);
   overflow: hidden;
-  max-height: calc(100vh - 280px);
+  height: calc(100vh - 280px);
+  min-height: 400px;
   overflow-y: auto;
 }
 
@@ -11617,7 +11618,8 @@ body.page-forwarding .fwd-no-match-sub {
     width: 100%;
   }
   .logs-table-wrap {
-    max-height: calc(100vh - 320px);
+    height: calc(100vh - 320px);
+    min-height: 300px;
   }
   .lt-col-guild {
     display: none;

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -11529,6 +11529,43 @@ body.page-forwarding .fwd-no-match-sub {
   margin: 0;
 }
 
+/* ── Pagination ─────────────────────────────────────────── */
+.logs-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 16px 0;
+}
+.pg-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 6px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 0.15s, border-color 0.15s;
+}
+.pg-btn:hover:not(:disabled) {
+  background: rgba(139, 92, 246, 0.15);
+  border-color: var(--accent);
+}
+.pg-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.pg-btn.pg-active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.pg-ellipsis {
+  color: var(--muted);
+  padding: 0 4px;
+  font-size: 0.85rem;
+}
+
 /* ── Animations ──────────────────────────────────────────── */
 @keyframes log-fade-out {
   from {

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -4161,11 +4161,18 @@ body {
   background-image: none;
 }
 
+#log-modal .modal-content {
+  height: 80vh;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
 #log-modal .modal-header {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 .log-search-input {
@@ -7085,6 +7092,20 @@ body.modal-open {
   scrollbar-gutter: stable;
 }
 
+#cfg-form .tip-bubble {
+  white-space: normal;
+  word-break: break-word;
+  overflow-x: hidden;
+  max-width: min(380px, calc(100vw - 32px));
+}
+#cfg-form input[type='number']::-webkit-inner-spin-button,
+#cfg-form input[type='number']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+#cfg-form input[type='number'] {
+  -moz-appearance: textfield;
+}
 #cfg-form .select {
   width: 100%;
   max-width: 100%;

--- a/code/admin/templates/index.html
+++ b/code/admin/templates/index.html
@@ -236,7 +236,6 @@
 
         <button type="button" class="btn btn-ghost push-right" data-log="server">View server logs</button>
         <button type="button" class="btn btn-ghost" data-log="client">View client logs</button>
-        <form method="post" action="/logs/clear"><button class="btn btn-ghost">Clear all logs</button></form>
       </div>
     </div>
 
@@ -293,7 +292,10 @@
     "DISABLE_ROLE_MENTIONS": "When enabled, role mentions will be disabled in mirrored messages to stop role pings.",
     "TAG_REPLY_MSG": "When enabled, messages that are replies will include a tag of the message being replied to.",
     "DB_CLEANUP_MSG": "When enabled, runs an hourly task to delete messages stored in the database that are older than 7
-    days."
+    days.",
+    "ON_DEMAND_WEBHOOKS": "When enabled, webhooks are only created when a channel receives its first message, instead of during sync. This makes server cloning much faster by skipping upfront webhook creation.",
+    "COPYCORD_AUTOSTART": "Automatically start the server and client when Copycord launches. Valid tokens are required.",
+    "LOG_MAX_SIZE_MB": "Maximum size of each log file in megabytes before older entries are pruned. Set to 0 to disable pruning."
     } %}
 
     <div class="card" id="global-config-card">
@@ -400,6 +402,36 @@
             </div>
           </div>
 
+          <div class="field">
+            <label for="COPYCORD_AUTOSTART" class="has-tip">
+              <span class="label-text">AUTO_START</span>
+              <button type="button" class="info-dot" aria-label="What is AUTO_START?"
+                aria-describedby="tip-COPYCORD_AUTOSTART"></button>
+              <span id="tip-COPYCORD_AUTOSTART" role="tooltip" class="tip-bubble">
+                {{ FIELD_TIPS['COPYCORD_AUTOSTART'] }}
+              </span>
+            </label>
+            <div class="select">
+              <select id="COPYCORD_AUTOSTART" name="COPYCORD_AUTOSTART">
+                <option value="false" {{ 'selected' if (env.get('COPYCORD_AUTOSTART','false')|lower)=='false' else '' }}>False</option>
+                <option value="true" {{ 'selected' if (env.get('COPYCORD_AUTOSTART','false')|lower)=='true' else '' }}>True</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="field">
+            <label for="LOG_MAX_SIZE_MB" class="has-tip">
+              <span class="label-text">MAX_LOG_SIZE_MB</span>
+              <button type="button" class="info-dot" aria-label="What is MAX_LOG_SIZE_MB?"
+                aria-describedby="tip-LOG_MAX_SIZE_MB"></button>
+              <span id="tip-LOG_MAX_SIZE_MB" role="tooltip" class="tip-bubble">
+                {{ FIELD_TIPS['LOG_MAX_SIZE_MB'] }}
+              </span>
+            </label>
+            <input type="number" id="LOG_MAX_SIZE_MB" name="LOG_MAX_SIZE_MB"
+              value="{{ env.get('LOG_MAX_SIZE_MB','10') }}" min="0" step="1" />
+          </div>
+
           <div class="btns">
             <button class="btn btn-ghost" type="submit" id="cfg-save-btn">Save</button>
             <button type="button" class="btn btn-ghost" id="cfg-cancel-btn">Cancel</button>
@@ -470,6 +502,9 @@
           <button type="button" id="log-close" class="icon-btn verify-close" aria-label="Close">✕</button>
         </div>
         <pre id="log-body" class="log-output"></pre>
+        <div class="btns" style="padding: 8px 16px; justify-content: flex-end;">
+          <button type="button" id="log-clear-btn" class="btn btn-ghost">Clear logs</button>
+        </div>
       </div>
     </div>
 

--- a/code/admin/templates/logs.html
+++ b/code/admin/templates/logs.html
@@ -219,6 +219,8 @@
                 </div>
             </div>
 
+            <div class="logs-pagination" id="logs-pagination" aria-label="Pagination"></div>
+
         </section>
     </main>
 

--- a/code/admin/templates/logs.html
+++ b/code/admin/templates/logs.html
@@ -188,6 +188,11 @@
                         </svg>
                         Clear Filters
                     </button>
+                    <button id="logs-refresh" class="btn-icon-sm" title="Refresh logs" aria-label="Refresh logs">
+                        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182M21.015 4.356v4.992" />
+                        </svg>
+                    </button>
                     <button id="logs-clear-all" class="btn-icon-sm" title="Clear all logs" aria-label="Clear all logs">
                         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5">
                             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />

--- a/code/client/client.py
+++ b/code/client/client.py
@@ -2645,7 +2645,7 @@ class ClientListener:
 def _autostart_enabled() -> bool:
     import os
 
-    return os.getenv("COPYCORD_AUTOSTART", "true").lower() in ("1", "true", "yes", "on")
+    return os.getenv("COPYCORD_AUTOSTART", "false").lower() in ("1", "true", "yes", "on")
 
 
 if __name__ == "__main__":

--- a/code/client/sitemap.py
+++ b/code/client/sitemap.py
@@ -313,7 +313,7 @@ class SitemapService:
             origin_ids = self._mapped_original_ids()
 
             if not origin_ids:
-                self.logger.info("[⚠️] No active guild mappings to clone. Please check your configuration.")
+                self.logger.info("[⚠️] No guild mappings found. Server cloning is disabled.")
                 return
 
             await self._build_and_send_selected(

--- a/code/common/config.py
+++ b/code/common/config.py
@@ -15,7 +15,7 @@ from typing import Optional
 from common.db import DBManager
 
 logger = logging.getLogger(__name__)
-CURRENT_VERSION = "v3.19.0"
+CURRENT_VERSION = "v3.20.0"
 
 
 class Config:
@@ -127,6 +127,7 @@ class Config:
             "DISABLE_ROLE_MENTIONS": False,
             "TAG_REPLY_MSG": False,
             "DB_CLEANUP_MSG": True,
+            "ON_DEMAND_WEBHOOKS": True,
         }
 
     async def setup_release_watcher(self, receiver, should_dm: bool = True):

--- a/code/control/control.py
+++ b/code/control/control.py
@@ -160,6 +160,7 @@ class ControlService:
             return {"ok": True, "status": "already-running", "pid": self._child.pid}
 
         env = self._load_env_for_child()
+        env["COPYCORD_AUTOSTART"] = "true"
 
         self._child = subprocess.Popen(
             [sys.executable, "-u", "-m", self.module],

--- a/code/server/commands.py
+++ b/code/server/commands.py
@@ -38,7 +38,11 @@ config = Config(logger=logger)
 
 _db_boot = DBManager(config.DB_PATH)
 try:
-    _ids = _db_boot.get_all_clone_guild_ids()
+    _ids = [
+        int(m["cloned_guild_id"])
+        for m in _db_boot.list_guild_mappings()
+        if m.get("cloned_guild_id")
+    ]
 except Exception:
     _ids = []
 
@@ -163,12 +167,24 @@ class CloneCommands(commands.Cog):
 
         Returns the new guild_ids list.
         """
+        new_ids = []
         try:
-            ids = self.db.get_all_clone_guild_ids() or []
+            mappings = self.db.list_guild_mappings()
+            for m in mappings:
+                raw = m.get("cloned_guild_id")
+                if raw:
+                    try:
+                        new_ids.append(int(raw))
+                    except (ValueError, TypeError):
+                        pass
+            new_ids = sorted(set(new_ids))
+            logger.debug(
+                "[commands] Refreshed command guilds: %d mapping(s), guild_ids=%s",
+                len(mappings),
+                new_ids,
+            )
         except Exception:
-            ids = []
-
-        new_ids = sorted({int(g) for g in ids if g})
+            logger.exception("[commands] Failed to refresh command guilds")
 
         for cmd in self.bot.application_commands:
             if getattr(cmd, "guild_ids", None) is not None:
@@ -210,7 +226,7 @@ class CloneCommands(commands.Cog):
         try:
             new_ids = self._refresh_command_guilds()
             await self.bot.sync_commands()
-            logger.debug("[✅] Server slash commands synced for: %s", new_ids)
+            logger.debug("[✅] Slash commands synced for guilds: %s", new_ids)
         except Exception:
             logger.exception("Slash command sync failed")
 
@@ -993,10 +1009,6 @@ class CloneCommands(commands.Cog):
         if not guild:
             return await ctx.followup.send("No guild context.", ephemeral=True)
 
-        RL_EMOJI = getattr(ActionType, "EMOJI", "EMOJI")
-        RL_STICKER = getattr(ActionType, "STICKER", "STICKER")
-        RL_ROLE = getattr(ActionType, "ROLE", "ROLE")
-
         deleted = skipped = failed = 0
         deleted_ids: list[int] = []
 
@@ -1075,7 +1087,6 @@ class CloneCommands(commands.Cog):
                         continue
 
                     try:
-                        await self.ratelimit.acquire(RL_EMOJI)
                         await em.delete(reason=f"Purge by {ctx.user.id}")
                         deleted += 1
                         deleted_ids.append(int(em.id))
@@ -1158,7 +1169,6 @@ class CloneCommands(commands.Cog):
                         continue
 
                     try:
-                        await self.ratelimit.acquire(RL_STICKER)
                         await st.delete(reason=f"Purge by {ctx.user.id}")
                         deleted += 1
                         deleted_ids.append(int(st.id))
@@ -1261,7 +1271,6 @@ class CloneCommands(commands.Cog):
                         continue
 
                     try:
-                        await self.ratelimit.acquire(RL_ROLE)
                         await role.delete(reason=f"Purge by {ctx.user.id}")
                         deleted += 1
                         deleted_ids.append(int(role.id))

--- a/code/server/emojis.py
+++ b/code/server/emojis.py
@@ -139,7 +139,7 @@ class EmojiManager:
             return
 
         async def _run_one():
-            await self._run_sync_for_guild(
+            return await self._run_sync_for_guild(
                 guild=guild,
                 emoji_data=emojis or [],
                 host_guild_id=host_id,
@@ -199,11 +199,13 @@ class EmojiManager:
                         guild_id=guild.id,
                         guild_name=getattr(guild, "name", None),
                     )
+                    return f"Emojis: {summary}"
                 else:
                     self._log(
                         "info",
                         "[😊] Emoji sync complete: no changes needed"
                     )
+                    return ""
 
             except asyncio.CancelledError:
                 self._log(

--- a/code/server/emojis.py
+++ b/code/server/emojis.py
@@ -266,6 +266,7 @@ class EmojiManager:
                         f"Deleted emoji '{row['cloned_emoji_name']}'",
                         guild_id=guild.id,
                         guild_name=getattr(guild, "name", None),
+                        extra={"original_emoji_id": int(orig_id), "clone_emoji_id": int(row["cloned_emoji_id"])},
                     )
                 except discord.Forbidden:
                     self._log(
@@ -315,6 +316,7 @@ class EmojiManager:
                         f"Renamed emoji '{cloned.name}' → '{name}'",
                         guild_id=guild.id,
                         guild_name=getattr(guild, "name", None),
+                        extra={"original_emoji_id": int(orig_id), "clone_emoji_id": int(cloned.id)},
                     )
                     self.db.upsert_emoji_mapping(
                         orig_id,
@@ -349,6 +351,7 @@ class EmojiManager:
                         f"Renamed emoji '{mapping['original_emoji_name']}' → '{name}'",
                         guild_id=guild.id,
                         guild_name=getattr(guild, "name", None),
+                        extra={"original_emoji_id": int(orig_id), "clone_emoji_id": int(cloned.id)},
                     )
                     self.db.upsert_emoji_mapping(
                         orig_id,
@@ -418,6 +421,7 @@ class EmojiManager:
                     f"Created emoji '{name}'",
                     guild_id=guild.id,
                     guild_name=getattr(guild, "name", None),
+                    extra={"original_emoji_id": int(orig_id), "clone_emoji_id": int(created_emo.id)},
                 )
                 self.db.upsert_emoji_mapping(
                     orig_id,
@@ -432,7 +436,14 @@ class EmojiManager:
                 else:
                     static_count += 1
             except discord.HTTPException as e:
-                if "50138" in str(e):
+                if "30008" in str(e):
+                    self._log(
+                        "warning",
+                        "[😊] Emoji limit reached; stopping emoji sync (%d created so far)",
+                        created,
+                    )
+                    break
+                elif "50138" in str(e):
                     size_failed += 1
                 else:
                     self._log(
@@ -444,16 +455,17 @@ class EmojiManager:
 
         if skipped_limit_static or skipped_limit_animated:
             self._log(
-                "info",
-                "[😊] Skipped %d static and %d animated due to limit (%d). Consider boosting.",
+                "debug",
+                "[😊] Skipped %d static and %d animated due to limit (%d).",
                 skipped_limit_static,
                 skipped_limit_animated,
                 limit,
             )
         if size_failed:
             self._log(
-                "info",
-                "[😊] Skipped some emojis because they still exceed 256 KiB after conversion."
+                "debug",
+                "[😊] Skipped %d emojis that still exceed 256 KiB after conversion.",
+                size_failed,
             )
         return deleted, renamed, created
 

--- a/code/server/helpers.py
+++ b/code/server/helpers.py
@@ -566,18 +566,12 @@ class VerifyController:
                         )
                         continue
 
-                    wait_t0 = time.perf_counter()
-                    await self.ratelimit.acquire(self._AT_DELETE)
-                    wait_ms = self._ms_since(wait_t0)
-                    op_t0 = time.perf_counter()
                     await ch.delete()
                     self.log.info(
-                        "[🗑️] Deleted orphan Category | req_id=%s name=%s id=%d wait_ms=%.1f op_ms=%.1f",
+                        "[🗑️] Deleted orphan Category | req_id=%s name=%s id=%d",
                         req_id,
                         ch.name,
                         ch.id,
-                        wait_ms,
-                        self._ms_since(op_t0),
                     )
                     results.append(
                         {
@@ -625,19 +619,13 @@ class VerifyController:
                         )
                         continue
 
-                    wait_t0 = time.perf_counter()
-                    await self.ratelimit.acquire(self._AT_DELETE)
-                    wait_ms = self._ms_since(wait_t0)
-                    op_t0 = time.perf_counter()
                     await ch.delete()
                     self.log.info(
-                        "[🗑️] Deleted orphan %s | req_id=%s name=%s id=%d wait_ms=%.1f op_ms=%.1f",
+                        "[🗑️] Deleted orphan %s | req_id=%s name=%s id=%d",
                         type(ch).__name__,
                         req_id,
                         getattr(ch, "name", "?"),
                         ch.id,
-                        wait_ms,
-                        self._ms_since(op_t0),
                     )
                     results.append(
                         {

--- a/code/server/helpers.py
+++ b/code/server/helpers.py
@@ -347,7 +347,7 @@ class VerifyController:
         if act == "list":
             ct0 = time.perf_counter()
             cats, chs = self._compute_orphans(guild)
-            self.log.info(
+            self.log.debug(
                 "Orphans listed | req_id=%s guild=%s cats=%d chs=%d took=%.1fms",
                 req_id,
                 guild.id,

--- a/code/server/permission_sync.py
+++ b/code/server/permission_sync.py
@@ -454,7 +454,7 @@ class ChannelPermissionSync:
                 clone_role_id = self._extract_cloned_role_id(row) or 0
                 if not clone_role_id:
                     self._log(
-                        "info",
+                        "debug",
                         "[perm-sync] #%s skip role %s: no cloned mapping",
                         getattr(ch, "id", "?"),
                         orig_role_id,

--- a/code/server/permission_sync.py
+++ b/code/server/permission_sync.py
@@ -111,9 +111,13 @@ class ChannelPermissionSync:
 
         async def _runner():
             try:
+                if self.bot.is_closed():
+                    return
                 await self._await_roles_done(
                     roles_manager, roles_handle_or_none, await_timeout
                 )
+                if self.bot.is_closed():
+                    return
                 parts = await self._sync_permissions(guild, sitemap, src_everyone_id)
                 if parts:
                     summary = "; ".join(parts)
@@ -431,7 +435,7 @@ class ChannelPermissionSync:
         role_items: List[dict],
         src_everyone_id: Optional[int],
     ) -> bool:
-        if not role_items:
+        if not role_items or self.bot.is_closed():
             return False
 
         guild = ch.guild
@@ -541,6 +545,7 @@ class ChannelPermissionSync:
                         guild_name=getattr(guild, "name", None),
                         channel_id=ch.id,
                         channel_name=getattr(ch, "name", None),
+                        extra={"clone_channel_id": int(ch.id)},
                     )
                 except Exception:
                     pass

--- a/code/server/permission_sync.py
+++ b/code/server/permission_sync.py
@@ -122,11 +122,13 @@ class ChannelPermissionSync:
                         "[🔐] Channel permission sync complete: %s",
                         summary,
                     )
+                    return f"Permissions: {summary}"
                 else:
                     self._log(
                         "info",
                         "[🔐] Channel permission sync complete: no changes needed",
                     )
+                    return ""
             except asyncio.CancelledError:
                 raise
             except Exception as e:
@@ -136,7 +138,7 @@ class ChannelPermissionSync:
                     e,
                 )
 
-        asyncio.create_task(_runner(), name=task_name)
+        return asyncio.create_task(_runner(), name=task_name)
 
     async def _await_roles_done(self, roles_manager, handle, timeout: float) -> None:
         try:
@@ -518,10 +520,6 @@ class ChannelPermissionSync:
             )
 
         try:
-            if self.ratelimit and self.rate_limiter_action is not None:
-                await self.ratelimit.acquire_for_guild(
-                    self.rate_limiter_action, int(guild.id)
-                )
             await ch._state.http.edit_channel(
                 ch.id,
                 permission_overwrites=payload_overwrites,

--- a/code/server/roles.py
+++ b/code/server/roles.py
@@ -232,7 +232,7 @@ class RoleManager:
                     return ""
 
             except asyncio.CancelledError:
-                self._log("warning", "[🧩] Role sync canceled.")
+                self._log("debug", "[🧩] Role sync canceled.")
             except Exception as e:
                 self._log("error", "[🧩] Role sync failed: %s", e)
             finally:

--- a/code/server/roles.py
+++ b/code/server/roles.py
@@ -217,16 +217,19 @@ class RoleManager:
                     parts.append(f"Repositioned {rearranged} roles")
 
                 if parts:
+                    summary = "; ".join(parts)
                     self._log(
                         "info",
                         "[🧩] Role sync complete: %s",
-                        "; ".join(parts),
+                        summary,
                     )
+                    return f"Roles: {summary}"
                 else:
                     self._log(
                         "info",
                         "[🧩] Role sync complete: no changes needed",
                     )
+                    return ""
 
             except asyncio.CancelledError:
                 self._log("warning", "[🧩] Role sync canceled.")

--- a/code/server/roles.py
+++ b/code/server/roles.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 import asyncio, logging, discord, aiohttp
 from typing import List, Dict, Tuple, Optional
-from server.rate_limiter import ActionType
 from server import logctx
 
 logger = logging.getLogger("server.roles")
@@ -44,6 +43,7 @@ class RoleManager:
         self._locks: dict[int, asyncio.Lock] = {}
 
         self.MAX_ROLES = 250
+        self._ROLE_OP_DELAY = 1.5
 
     async def _emit_log(
         self,
@@ -193,6 +193,8 @@ class RoleManager:
     ) -> None:
         lock = self._get_lock_for_clone(clone_id)
         async with lock:
+            if self.bot.is_closed():
+                return
             try:
                 deleted, updated, created, rearranged = await self._sync(
                     guild=guild,
@@ -232,7 +234,16 @@ class RoleManager:
                     return ""
 
             except asyncio.CancelledError:
-                self._log("debug", "[🧩] Role sync canceled.")
+                if self.bot.is_closed():
+                    return
+                task = asyncio.current_task()
+                if task and task.cancelled():
+                    self._log("debug", "[🧩] Role sync canceled (task canceled).")
+                else:
+                    self._log(
+                        "warning",
+                        "[🧩] Role sync interrupted by discord.py reconnect; will retry next sync cycle",
+                    )
             except Exception as e:
                 self._log("error", "[🧩] Role sync failed: %s", e)
             finally:
@@ -278,7 +289,6 @@ class RoleManager:
             return None, 0, can_create, create_suppressed_logged
 
         try:
-            await self.ratelimit.acquire_for_guild(ActionType.ROLE, cloned_guild_id)
             kwargs = dict(
                 name=want_name,
                 colour=want_color,
@@ -297,6 +307,7 @@ class RoleManager:
                     kwargs["display_icon"] = unicode_emoji
 
             cloned = await guild.create_role(**kwargs)
+            await asyncio.sleep(self._ROLE_OP_DELAY)
 
             self.db.upsert_role_mapping(
                 orig_id,
@@ -421,8 +432,8 @@ class RoleManager:
                     continue
 
                 try:
-                    await self.ratelimit.acquire_for_guild(ActionType.ROLE, clone_id)
                     await cloned_role.delete()
+                    await asyncio.sleep(self._ROLE_OP_DELAY)
                     deleted += 1
                     self._log(
                         "info",
@@ -435,6 +446,7 @@ class RoleManager:
                         f"Deleted role '{cloned_role.name}'",
                         guild_id=clone_id,
                         guild_name=getattr(guild, "name", None),
+                        extra={"original_role_id": int(orig_id), "clone_role_id": int(cloned_role.id)},
                     )
 
                 except Exception as e:
@@ -481,12 +493,10 @@ class RoleManager:
                     and cloned_role.position < bot_top
                 ):
                     try:
-                        await self.ratelimit.acquire_for_guild(
-                            ActionType.ROLE, clone_id
-                        )
                         await cloned_role.delete(
                             reason="Blocked by Copycord role blocklist"
                         )
+                        await asyncio.sleep(self._ROLE_OP_DELAY)
                         self._log(
                             "info",
                             "[🧩] Deleted blocked role %s (%d)",
@@ -549,7 +559,6 @@ class RoleManager:
                     continue
 
                 try:
-                    await self.ratelimit.acquire_for_guild(ActionType.ROLE, clone_id)
                     kwargs = dict(
                         name=want_name,
                         colour=want_color,
@@ -568,6 +577,7 @@ class RoleManager:
                             kwargs["display_icon"] = want_unicode_emoji
 
                     new_role = await guild.create_role(**kwargs)
+                    await asyncio.sleep(self._ROLE_OP_DELAY)
                     created += 1
 
                     self.db.upsert_role_mapping(
@@ -590,6 +600,7 @@ class RoleManager:
                         f"Created role '{new_role.name}'",
                         guild_id=clone_id,
                         guild_name=getattr(guild, "name", None),
+                        extra={"original_role_id": int(orig_id), "clone_role_id": int(new_role.id)},
                     )
 
                     can_create = len(guild.roles) < self.MAX_ROLES
@@ -687,9 +698,6 @@ class RoleManager:
                         "; ".join(changes),
                     )
                     try:
-                        await self.ratelimit.acquire_for_guild(
-                            ActionType.ROLE, clone_id
-                        )
                         kwargs = dict(
                             name=want_name,
                             colour=want_color,
@@ -710,6 +718,7 @@ class RoleManager:
                                 kwargs["display_icon"] = None
 
                         await cloned_role.edit(**kwargs)
+                        await asyncio.sleep(self._ROLE_OP_DELAY)
                         updated += 1
 
                         self.db.upsert_role_mapping(
@@ -730,6 +739,7 @@ class RoleManager:
                             f"Updated role '{cloned_role.name}' ({'; '.join(changes)})",
                             guild_id=clone_id,
                             guild_name=getattr(guild, "name", None),
+                            extra={"clone_role_id": int(cloned_role.id), "changes": changes},
                         )
 
                     except Exception as e:
@@ -928,8 +938,6 @@ class RoleManager:
             payload.append({"id": str(role.id), "position": pos})
 
         try:
-            await self.ratelimit.acquire_for_guild(ActionType.ROLE, clone_id)
-
             await guild.edit_role_positions(
                 positions=positions, reason="Copycord role order sync"
             )

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -328,6 +328,11 @@ class ServerReceiver:
     ):
         """Persist an event log entry and broadcast it to the admin UI."""
         try:
+            merged_extra = dict(extra) if extra else {}
+            sync_id = logctx.sync_display_id.get()
+            if sync_id:
+                merged_extra.setdefault("sync_task_id", sync_id)
+
             log_id = self.db.add_event_log(
                 event_type=event_type,
                 details=details,
@@ -337,7 +342,7 @@ class ServerReceiver:
                 channel_name=channel_name,
                 category_id=category_id,
                 category_name=category_name,
-                extra=extra,
+                extra=merged_extra if merged_extra else None,
             )
             await self.bus.publish("event_log", {
                 "log_id": log_id,
@@ -671,6 +676,8 @@ class ServerReceiver:
                             try:
                                 res = fut.result()
                             except asyncio.CancelledError:
+                                if getattr(self, "_shutting_down", False):
+                                    return
                                 logger.info(
                                     "[♻️] Sync task %s superseded by newer sitemap", _did
                                 )
@@ -1994,7 +2001,7 @@ class ServerReceiver:
 
                     struct_detail = "; ".join(parts) if parts else ""
                     struct_log = struct_detail or "No changes needed"
-                    logger.info("[🏗️] Structure sync complete: %s", struct_log)
+                    logger.info("[🛠️] Structure sync complete: %s", struct_log)
 
             with self._clone_log_label(int(target_clone_gid)):
                 self._schedule_flush()
@@ -2296,6 +2303,7 @@ class ServerReceiver:
                 f"Updated guild metadata: {', '.join(sorted(set(changed_fields)))}",
                 guild_id=guild.id,
                 guild_name=guild.name,
+                extra={"changed_fields": changed_fields},
             )
         except Exception:
             logger.warning(
@@ -2595,9 +2603,9 @@ class ServerReceiver:
 
                 if not cat_obj:
                     try:
-                        cat_obj = await guild.create_category(
+                        cat_obj = await asyncio.shield(guild.create_category(
                             upstream_name or "Category"
-                        )
+                        ))
                         created += 1
                         logger.info(
                             "[➕] Created category '%s' #%d",
@@ -3693,6 +3701,7 @@ class ServerReceiver:
                         guild_name=getattr(guild, "name", None),
                         channel_id=ch.id,
                         channel_name=ch.name,
+                        extra={"original_channel_id": int(orig_id), "clone_channel_id": int(ch.id)},
                     )
                 elif is_stage_ch and stage_changed_here:
                     logger.info(
@@ -3708,6 +3717,7 @@ class ServerReceiver:
                         guild_name=getattr(guild, "name", None),
                         channel_id=ch.id,
                         channel_name=ch.name,
+                        extra={"original_channel_id": int(orig_id), "clone_channel_id": int(ch.id)},
                     )
                 elif is_forum_ch and forum_changed_here:
                     logger.info(
@@ -3723,6 +3733,7 @@ class ServerReceiver:
                         guild_name=getattr(guild, "name", None),
                         channel_id=ch.id,
                         channel_name=ch.name,
+                        extra={"original_channel_id": int(orig_id), "clone_channel_id": int(ch.id)},
                     )
                 else:
                     logger.info(
@@ -3738,6 +3749,7 @@ class ServerReceiver:
                         guild_name=getattr(guild, "name", None),
                         channel_id=ch.id,
                         channel_name=ch.name,
+                        extra={"original_channel_id": int(orig_id), "clone_channel_id": int(ch.id)},
                     )
 
             except Exception as e:
@@ -3950,14 +3962,14 @@ class ServerReceiver:
 
             if not ch:
 
-                ch = await guild.create_forum_channel(
+                ch = await asyncio.shield(guild.create_forum_channel(
                     name=name,
                     category=(
                         guild.get_channel(cloned_parent_id)
                         if cloned_parent_id
                         else None
                     ),
-                )
+                ))
                 logger.info("[➕] Created forum channel '%s' #%d", name, ch.id)
                 created += 1
                 await self._emit_event_log(
@@ -3969,6 +3981,7 @@ class ServerReceiver:
                     channel_name=name,
                     category_id=cloned_parent_id,
                     category_name=_cat_name_from_sitemap(parent_id),
+                    extra={"original_channel_id": orig_id, "clone_channel_id": int(ch.id)},
                 )
 
                 await _ensure_forum_webhook_url(
@@ -3993,6 +4006,7 @@ class ServerReceiver:
                         guild_name=getattr(guild, "name", None),
                         channel_id=ch.id,
                         channel_name=name,
+                        extra={"original_channel_id": orig_id, "clone_channel_id": int(ch.id)},
                     )
 
                 want_parent = (
@@ -4014,6 +4028,7 @@ class ServerReceiver:
                         channel_name=getattr(ch, "name", None),
                         category_id=cloned_parent_id,
                         category_name=getattr(want_parent, "name", None),
+                        extra={"original_channel_id": orig_id, "clone_channel_id": int(ch.id)},
                     )
 
                 await _ensure_forum_webhook_url(
@@ -4136,7 +4151,9 @@ class ServerReceiver:
                 self.db.delete_channel_mapping(int(original_id))
             per.pop(int(original_id), None)
 
-        ch = await self._create_channel(guild, "voice", original_name, category)
+        ch = await asyncio.shield(
+            self._create_channel(guild, "voice", original_name, category, original_channel_id=original_id)
+        )
 
         voice_changes: dict[str, object] = {}
         if bitrate is not None:
@@ -4308,9 +4325,9 @@ class ServerReceiver:
                 self.db.delete_channel_mapping(int(original_id))
             per.pop(int(original_id), None)
 
-        ch = await self._create_channel(
-            guild, "stage", original_name, category, topic=topic
-        )
+        ch = await asyncio.shield(self._create_channel(
+            guild, "stage", original_name, category, topic=topic, original_channel_id=original_id
+        ))
 
         if ch is None:
             logger.warning(
@@ -4621,6 +4638,7 @@ class ServerReceiver:
                             guild_name=getattr(guild, "name", None),
                             channel_id=ch.id,
                             channel_name=ch.name,
+                            extra={"original_channel_id": int(orig), "clone_channel_id": int(ch.id)},
                         )
 
                         mrow = per.get(int(orig)) or mrow or {}
@@ -5077,6 +5095,7 @@ class ServerReceiver:
         name: str,
         category: CategoryChannel | None,
         topic: str | None = None,
+        original_channel_id: int | None = None,
     ) -> Union[TextChannel, ForumChannel, discord.VoiceChannel, discord.StageChannel]:
         """
         Create a channel of `kind` ('text'|'news'|'forum'|'voice'|'stage') named `name` under
@@ -5126,6 +5145,7 @@ class ServerReceiver:
             channel_name=name,
             category_id=getattr(category, "id", None) if category else None,
             category_name=getattr(category, "name", None) if category else None,
+            extra={"original_channel_id": original_channel_id, "clone_channel_id": int(ch.id)} if original_channel_id else None,
         )
 
         if kind == "news":
@@ -5140,6 +5160,7 @@ class ServerReceiver:
                         guild_name=getattr(guild, "name", None),
                         channel_id=ch.id,
                         channel_name=name,
+                        extra={"original_channel_id": original_channel_id, "clone_channel_id": int(ch.id)} if original_channel_id else None,
                     )
                 except HTTPException as e:
                     logger.warning(
@@ -5254,6 +5275,7 @@ class ServerReceiver:
                     guild_name=getattr(ch.guild, "name", None),
                     channel_id=ch.id,
                     channel_name=target,
+                    extra={"original_channel_id": int(orig_source_id), "clone_channel_id": int(ch.id)},
                 )
                 return True, "pinned_enforced"
             else:
@@ -5265,6 +5287,7 @@ class ServerReceiver:
                     guild_name=getattr(ch.guild, "name", None),
                     channel_id=ch.id,
                     channel_name=target,
+                    extra={"original_channel_id": int(orig_source_id), "clone_channel_id": int(ch.id)},
                 )
                 return True, "match_upstream"
 
@@ -5345,6 +5368,7 @@ class ServerReceiver:
                                 getattr(ch, "name", ch.id),
                                 getattr(clone_cat, "name", clone_cat.id),
                             )
+                            _ch_orig_id = next((k for k, v in ((self.chan_map_by_clone or {}).get(int(guild.id), {}) or {}).items() if int((v if isinstance(v, dict) else dict(v)).get("cloned_channel_id", 0)) == int(ch.id)), None)
                             await self._emit_event_log(
                                 "channel_deleted",
                                 f"Deleted channel '#{getattr(ch, 'name', ch.id)}' (category '{getattr(clone_cat, 'name', clone_cat.id)}' removed)",
@@ -5354,6 +5378,7 @@ class ServerReceiver:
                                 channel_name=getattr(ch, "name", None),
                                 category_id=clone_cat_id,
                                 category_name=getattr(clone_cat, "name", None),
+                                extra={"original_channel_id": int(_ch_orig_id), "clone_channel_id": int(ch.id)} if _ch_orig_id is not None else None,
                             )
                         except Exception:
                             logger.debug(
@@ -5385,6 +5410,7 @@ class ServerReceiver:
                         guild_name=getattr(guild, "name", None),
                         category_id=clone_cat_id,
                         category_name=getattr(clone_cat, "name", None),
+                        extra={"original_category_id": int(orig_id), "clone_category_id": int(clone_cat_id)},
                     )
                 except Exception:
                     logger.debug(
@@ -5549,6 +5575,7 @@ class ServerReceiver:
                             guild_name=getattr(guild, "name", None),
                             channel_id=ch.id,
                             channel_name=getattr(ch, "name", None),
+                            extra={"original_channel_id": int(orig_id), "clone_channel_id": int(ch.id)},
                         )
                         deleted_here = True
                     except discord.HTTPException as e:
@@ -5780,7 +5807,7 @@ class ServerReceiver:
                     self.cat_map[int(original_id)] = dict(entry)
                     return cat, False
 
-        cat = await guild.create_category(name)
+        cat = await asyncio.shield(guild.create_category(name))
         logger.info("[➕] Created category '%s' #%d", name, cat.id)
         await self._emit_event_log(
             "category_created",
@@ -5832,6 +5859,7 @@ class ServerReceiver:
                 guild_name=getattr(ch.guild, "name", None),
                 channel_id=ch.id,
                 channel_name=getattr(ch, "name", None),
+                extra={"clone_channel_id": int(ch.id)},
             )
             if hasattr(self, "_wh_meta"):
                 self._wh_meta.clear()
@@ -5915,6 +5943,13 @@ class ServerReceiver:
         *,
         clone_messages: bool = True,
     ) -> Tuple[int, int, str]:
+        if host_guild_id and int(host_guild_id) == int(guild.id):
+            logger.error(
+                "[BUG] host_guild_id == clone guild_id (%s) for channel '%s' (orig=%s). "
+                "This would create a bad mapping. Skipping.",
+                host_guild_id, original_name, original_id,
+            )
+            return
         if self._shutting_down:
             return
 
@@ -5988,7 +6023,9 @@ class ServerReceiver:
             per.pop(int(original_id), None)
 
         kind = "news" if int(channel_type) == discord.ChannelType.news.value else "text"
-        ch = await self._create_channel(guild, kind, original_name, category)
+        ch = await asyncio.shield(
+            self._create_channel(guild, kind, original_name, category, original_channel_id=original_id)
+        )
 
         self.db.upsert_channel_mapping(
             int(original_id),
@@ -6163,6 +6200,7 @@ class ServerReceiver:
                     channel_name=getattr(ch, "name", None),
                     category_id=desired_parent_clone_id,
                     category_name=getattr(desired_parent, "name", None),
+                    extra={"original_channel_id": int(orig_id), "clone_channel_id": int(ch.id)},
                 )
             except Exception:
                 logger.warning(
@@ -6365,8 +6403,8 @@ class ServerReceiver:
                     fresh["original_parent_category_id"],
                     fresh["cloned_parent_category_id"],
                     ctype,
-                    original_guild_id=host_guild_id,
-                    cloned_guild_id=guild.id,
+                    original_guild_id=fresh.get("original_guild_id"),
+                    cloned_guild_id=fresh.get("cloned_guild_id") or guild.id,
                 )
 
                 logger.debug(
@@ -6529,6 +6567,7 @@ class ServerReceiver:
                         guild_name=getattr(g, "name", None),
                         channel_id=cloned_tid,
                         channel_name=getattr(t, "name", None),
+                        extra={"original_thread_id": int(orig_tid), "clone_thread_id": int(cloned_tid)},
                     )
                 else:
                     logger.debug(
@@ -8607,6 +8646,9 @@ class ServerReceiver:
                         ctx_gid = host_guild_id or None
 
                     role_mentions = []
+                    clone_cid = mapping.get("cloned_channel_id") or mapping.get(
+                        "clone_channel_id"
+                    )
                     if not is_backfill:
                         try:
 
@@ -10993,10 +11035,10 @@ class ServerReceiver:
 
         row = self._bf_pick_mapping_for_target(original_id)
         if not row:
-            logger.warning(
+            logger.debug(
                 "[bf] no mapping for channel=%s; using live forward", original_id
             )
-            await self.handle_message(data)
+            await self.forward_message(data)
             return
 
         clone_id = None
@@ -11017,10 +11059,10 @@ class ServerReceiver:
                 break
 
         if not primary_url:
-            logger.warning(
-                "[bf] mapping found but no webhook URL | ch=%s row=%s", original_id, row
+            logger.debug(
+                "[bf] mapping found but no webhook URL | ch=%s; forwarding for on-demand webhook creation", original_id
             )
-            await self.handle_message(data)
+            await self.forward_message(data)
             return
 
         st = self.backfill._progress.get(int(original_id))

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -129,7 +129,7 @@ class _GuildPrefixFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         try:
-            prefix = logctx.guild_prefix()
+            prefix = logctx.format_prefix()
         except Exception:
             prefix = ""
 
@@ -1992,12 +1992,11 @@ class ServerReceiver:
                         if perm_task:
                             bg_tasks.append(perm_task)
 
-            struct_detail = "; ".join(parts) if parts else ""
-            struct_log = struct_detail or "No changes needed"
+                    struct_detail = "; ".join(parts) if parts else ""
+                    struct_log = struct_detail or "No changes needed"
+                    logger.info("[🏗️] Structure sync complete: %s", struct_log)
 
             with self._clone_log_label(int(target_clone_gid)):
-                logger.info("[🏗️] Structure sync complete: %s", struct_log)
-
                 self._schedule_flush()
 
                 pending_wh = self._pending_webhook_channels.pop(int(target_clone_gid), [])

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -44,7 +44,6 @@ from common.common_helpers import resolve_mapping_settings
 from common.websockets import WebsocketManager, AdminBus
 from common.db import DBManager
 from server.rate_limiter import RateLimitManager, ActionType
-from server.discord_hooks import install_discord_rl_probe
 from server.proxy_rotator import ProxyRotator, patch_discord_http
 from server.emojis import EmojiManager
 from server.stickers import StickerManager
@@ -187,6 +186,7 @@ class ServerReceiver:
         self._sitemap_queues: dict[int, asyncio.Queue] = {}
         self._sitemap_workers: dict[int, asyncio.Task] = {}
         self._guild_sync_locks: dict[int, asyncio.Lock] = {}
+        self._running_sync_tasks: dict[int, asyncio.Task] = {}
         self._pending_msgs: dict[int, list[dict]] = {}
         self._pending_thread_msgs: List[Dict] = []
         self._flush_bg_task: asyncio.Task | None = None
@@ -195,6 +195,7 @@ class ServerReceiver:
         self._flush_thread_targets: set[int] = set()
         self._webhook_locks: Dict[int, asyncio.Lock] = {}
         self._new_webhook_gate = asyncio.Lock()
+        self._pending_webhook_channels: dict[int, list[dict]] = {}
         self.sticker_map: dict[int, dict] = {}
         self.cat_map: dict[int, dict] = {}
         self.chan_map: dict[int, dict] = {}
@@ -270,7 +271,6 @@ class ServerReceiver:
             emit_event_log=self._emit_event_log,
         )
         self.onjoin = OnJoinService(self.bot, self.db, logger.getChild("OnJoin"))
-        install_discord_rl_probe(self.ratelimit)
 
         self.proxy_rotator = ProxyRotator()
         self._init_proxy_rotator()
@@ -672,7 +672,7 @@ class ServerReceiver:
                                 res = fut.result()
                             except asyncio.CancelledError:
                                 logger.info(
-                                    "[🗑️] Canceled sync task %s cloning disabled", _did
+                                    "[♻️] Sync task %s superseded by newer sitemap", _did
                                 )
                             except Exception as e:
                                 logger.error(
@@ -686,7 +686,7 @@ class ServerReceiver:
                                     "CANCELED"
                                 ):
                                     logger.info(
-                                        "[🗑️] Canceled sync task %s cloning disabled",
+                                        "[🗑️] Sync task %s canceled: cloning disabled",
                                         _did,
                                     )
                                 else:
@@ -698,7 +698,17 @@ class ServerReceiver:
 
                 for tid, did, sm in items:
                     cgid = int((sm.get("target") or {}).get("cloned_guild_id") or 0)
+
+                    prev = self._running_sync_tasks.get(cgid)
+                    if prev and not prev.done():
+                        prev.cancel()
+                        logger.info(
+                            "[♻️] Canceling running sync for clone %s — newer sitemap arrived",
+                            cgid,
+                        )
+
                     task = asyncio.create_task(self.sync_structure(tid, sm))
+                    self._running_sync_tasks[cgid] = task
                     task.add_done_callback(
                         lambda fut, _did=did, _cgid=cgid: _on_done(fut, _did, _cgid)
                     )
@@ -773,7 +783,7 @@ class ServerReceiver:
                     )
                 else:
                     logger.warning(
-                        "[⚠️] No guild mappings found. Nothing is currently set to clone."
+                        "[⚠️] No guild mappings found. Server cloning is disabled."
                     )
             else:
                 if num_paused:
@@ -978,7 +988,7 @@ class ServerReceiver:
         try:
 
             if not self.db.is_clone_guild_id(channel.guild.id):
-                logger.info(
+                logger.debug(
                     "[🛑] Ignoring delete of channel %s in non-clone guild %s",
                     channel.id,
                     channel.guild.id,
@@ -1885,7 +1895,7 @@ class ServerReceiver:
                     )
                     return "Error: clone guild missing"
 
-                bg_jobs: list[str] = []
+                self._pending_webhook_channels[int(target_clone_gid)] = []
 
                 self._load_mappings()
 
@@ -1896,19 +1906,25 @@ class ServerReceiver:
                         host_guild_id=host_guild_id,
                     )
 
+                    bg_tasks: list[asyncio.Task] = []
+
                     if settings.get("CLONE_EMOJI", True):
                         self.emojis.kickoff_sync(
                             sitemap.get("emojis", []),
                             host_guild_id,
                             target_clone_guild_id=int(target_clone_gid),
                         )
-                        bg_jobs.append("emoji")
+                        _et = self.emojis._tasks.get(int(target_clone_gid))
+                        if _et:
+                            bg_tasks.append(_et)
 
                     if settings.get("CLONE_STICKER", True):
                         self.stickers.kickoff_sync(
                             target_clone_guild_id=int(target_clone_gid)
                         )
-                        bg_jobs.append("sticker")
+                        _st = self.stickers._tasks.get(int(target_clone_gid))
+                        if _st:
+                            bg_tasks.append(_st)
 
                     roles_handle = None
                     if settings.get("CLONE_ROLES", True):
@@ -1924,7 +1940,8 @@ class ServerReceiver:
                             rearrange_roles=settings.get("REARRANGE_ROLES", False),
                             clone_role_icons=settings.get("CLONE_ROLE_ICONS", False),
                         )
-                        bg_jobs.append("roles")
+                        if roles_handle:
+                            bg_tasks.append(roles_handle)
 
                     cat_created, ch_repaired, repaired_ids = (
                         await self._repair_deleted_categories(guild, sitemap)
@@ -1966,19 +1983,49 @@ class ServerReceiver:
                     if settings.get(
                         "MIRROR_CHANNEL_PERMISSIONS", False
                     ) and settings.get("CLONE_ROLES", False):
-                        self.perms.schedule_after_role_sync(
+                        perm_task = self.perms.schedule_after_role_sync(
                             roles_manager=self.roles,
                             roles_handle_or_none=roles_handle,
                             guild=guild,
                             sitemap=sitemap,
                         )
-                        bg_jobs.append("channel-perms")
+                        if perm_task:
+                            bg_tasks.append(perm_task)
 
-            main_summary = "; ".join(parts) if parts else "No structure changes needed"
+            struct_detail = "; ".join(parts) if parts else ""
+            struct_log = struct_detail or "No changes needed"
 
-            self._schedule_flush()
+            with self._clone_log_label(int(target_clone_gid)):
+                logger.info("[🏗️] Structure sync complete: %s", struct_log)
 
-            return main_summary
+                self._schedule_flush()
+
+                pending_wh = self._pending_webhook_channels.pop(int(target_clone_gid), [])
+                if pending_wh and not settings.get("ON_DEMAND_WEBHOOKS", True):
+                    wh_task = asyncio.ensure_future(self._create_pending_webhooks(pending_wh))
+                    bg_tasks.append(wh_task)
+                elif pending_wh:
+                    logger.debug(
+                        "[🔗] Skipping %d webhook creates (ON_DEMAND_WEBHOOKS=True)",
+                        len(pending_wh),
+                    )
+
+                summaries = []
+                if struct_detail:
+                    summaries.append(f"Structure: {struct_detail}")
+
+                if bg_tasks:
+                    try:
+                        bg_results = await asyncio.shield(
+                            asyncio.gather(*bg_tasks, return_exceptions=True)
+                        )
+                        for r in bg_results:
+                            if isinstance(r, str) and r:
+                                summaries.append(r)
+                    except asyncio.CancelledError:
+                        raise
+
+                return "; ".join(summaries) if summaries else "No changes needed"
 
         finally:
             self.proxy_rotator.set_enabled(False)
@@ -2235,7 +2282,6 @@ class ServerReceiver:
             return parts
 
         try:
-            await self.ratelimit.acquire_for_guild(ActionType.EDIT_CHANNEL, guild.id)
             await guild.edit(**changes)
             logger.info(
                 "[🏛️] Updated guild metadata for '%s' (%d): %s",
@@ -2396,9 +2442,6 @@ class ServerReceiver:
 
         async def _ensure_prereqs():
             try:
-                await self.ratelimit.acquire_for_guild(
-                    ActionType.EDIT_CHANNEL, guild.id
-                )
                 await guild.edit(
                     verification_level=getattr(discord.VerificationLevel, "medium"),
                     explicit_content_filter=getattr(
@@ -2436,7 +2479,6 @@ class ServerReceiver:
             return parts
 
         try:
-            await self.ratelimit.acquire_for_guild(ActionType.EDIT_CHANNEL, guild.id)
             await guild.edit(**patch_kwargs)
         except Exception as e:
             logger.debug(
@@ -2452,16 +2494,10 @@ class ServerReceiver:
         if not ok1 and want_enabled:
 
             try:
-                await self.ratelimit.acquire_for_guild(
-                    ActionType.EDIT_CHANNEL, guild.id
-                )
                 await guild.edit(rules_channel=None, public_updates_channel=None)
             except Exception:
                 pass
             try:
-                await self.ratelimit.acquire_for_guild(
-                    ActionType.EDIT_CHANNEL, guild.id
-                )
                 await guild.edit(
                     community=True, rules_channel=rc, public_updates_channel=uc
                 )
@@ -2560,19 +2596,13 @@ class ServerReceiver:
 
                 if not cat_obj:
                     try:
-                        await self.ratelimit.acquire_for_guild(
-                            ActionType.CREATE_CHANNEL, guild.id
-                        )
                         cat_obj = await guild.create_category(
                             upstream_name or "Category"
                         )
                         created += 1
                         logger.info(
-                            "[repair:category-created] guild=%s(%d) orig_cat=%d name=%r new_id=%d",
-                            guild.name,
-                            guild.id,
-                            orig_cat_id,
-                            upstream_name,
+                            "[➕] Created category '%s' #%d",
+                            upstream_name or "Category",
                             int(cat_obj.id),
                         )
                         await self._emit_event_log(
@@ -2650,9 +2680,6 @@ class ServerReceiver:
                         )
                         continue
 
-                    await self.ratelimit.acquire_for_guild(
-                        ActionType.EDIT_CHANNEL, guild.id
-                    )
                     await ch.edit(category=cat_obj)
                     reparented += 1
                     repaired_ids.add(int(ch.id))
@@ -3601,10 +3628,6 @@ class ServerReceiver:
                 continue
 
             try:
-                await self.ratelimit.acquire_for_guild(
-                    ActionType.EDIT_CHANNEL, guild.id
-                )
-
                 if changes:
                     await ch.edit(**changes)
 
@@ -3725,10 +3748,6 @@ class ServerReceiver:
 
         for ch, desired_req in require_tag_ops:
             try:
-                await self.ratelimit.acquire_for_guild(
-                    ActionType.EDIT_CHANNEL, guild.id
-                )
-
                 flags = getattr(ch, "flags", None)
                 flag_changes: Dict[str, object] = {}
 
@@ -3855,14 +3874,16 @@ class ServerReceiver:
         ) -> str | None:
             url = existing_url
             if not url and clone_messages:
-
-                wh = await self._create_webhook_safely(
-                    ch, "Copycord", await self._get_default_avatar_bytes()
-                )
-                if wh and getattr(wh, "id", None) and getattr(wh, "token", None):
-                    url = f"https://discord.com/api/webhooks/{wh.id}/{wh.token}"
-                else:
-                    url = None
+                self._pending_webhook_channels.setdefault(int(guild.id), []).append({
+                    "original_id": orig_id,
+                    "original_name": name,
+                    "cloned_channel_id": int(ch.id),
+                    "parent_id": int(parent_id) if parent_id else None,
+                    "cloned_parent_id": cloned_parent_id,
+                    "channel_type": ChannelType.forum.value,
+                    "host_guild_id": host_guild_id,
+                    "cloned_guild_id": int(guild.id),
+                })
 
             self.db.upsert_channel_mapping(
                 original_channel_id=orig_id,
@@ -3930,9 +3951,6 @@ class ServerReceiver:
 
             if not ch:
 
-                await self.ratelimit.acquire_for_guild(
-                    ActionType.CREATE_CHANNEL, guild.id
-                )
                 ch = await guild.create_forum_channel(
                     name=name,
                     category=(
@@ -3966,9 +3984,6 @@ class ServerReceiver:
             else:
 
                 if (ch.name or "") != name:
-                    await self.ratelimit.acquire_for_guild(
-                        ActionType.EDIT_CHANNEL, guild.id
-                    )
                     await ch.edit(name=name)
                     renamed += 1
                     logger.info("[✏️] Renamed forum #%d to %s", ch.id, name)
@@ -3985,9 +4000,6 @@ class ServerReceiver:
                     guild.get_channel(cloned_parent_id) if cloned_parent_id else None
                 )
                 if want_parent and getattr(ch, "category_id", None) != cloned_parent_id:
-                    await self.ratelimit.acquire_for_guild(
-                        ActionType.EDIT_CHANNEL, guild.id
-                    )
                     await ch.edit(category=want_parent)
                     logger.info(
                         "[📁] Moved forum #%d under category #%d",
@@ -4087,23 +4099,16 @@ class ServerReceiver:
 
             if ch:
                 if not wh_url and clone_messages:
-                    wh = await self._create_webhook_safely(
-                        ch, "Copycord", await self._get_default_avatar_bytes()
-                    )
-                    wh_url = f"https://discord.com/api/webhooks/{wh.id}/{wh.token}"
-                    self.db.upsert_channel_mapping(
-                        int(original_id),
-                        original_name,
-                        int(clone_id),
-                        wh_url,
-                        int(parent_id) if parent_id is not None else None,
-                        int(category.id) if category else None,
-                        int(channel_type),
-                        original_guild_id=(
-                            int(host_guild_id) if host_guild_id is not None else None
-                        ),
-                        cloned_guild_id=int(guild.id),
-                    )
+                    self._pending_webhook_channels.setdefault(int(guild.id), []).append({
+                        "original_id": int(original_id),
+                        "original_name": original_name,
+                        "cloned_channel_id": int(clone_id),
+                        "parent_id": int(parent_id) if parent_id is not None else None,
+                        "cloned_parent_id": int(category.id) if category else None,
+                        "channel_type": int(channel_type),
+                        "host_guild_id": int(host_guild_id) if host_guild_id is not None else None,
+                        "cloned_guild_id": int(guild.id),
+                    })
 
                 per[int(original_id)] = {
                     "original_channel_id": int(original_id),
@@ -4148,9 +4153,6 @@ class ServerReceiver:
 
         if voice_changes:
             try:
-                await self.ratelimit.acquire_for_guild(
-                    ActionType.EDIT_CHANNEL, guild.id
-                )
                 await ch.edit(**voice_changes)
                 logger.info(
                     "[🔊] Set voice properties for '%s' #%d: %s",
@@ -4165,18 +4167,11 @@ class ServerReceiver:
                     e,
                 )
 
-        url = None
-        if clone_messages:
-            wh = await self._create_webhook_safely(
-                ch, "Copycord", await self._get_default_avatar_bytes()
-            )
-            url = f"https://discord.com/api/webhooks/{wh.id}/{wh.token}"
-
         self.db.upsert_channel_mapping(
             int(original_id),
             original_name,
             int(ch.id),
-            url,
+            None,
             int(parent_id) if parent_id is not None else None,
             int(category.id) if category else None,
             int(channel_type),
@@ -4188,7 +4183,7 @@ class ServerReceiver:
             "original_channel_id": int(original_id),
             "original_channel_name": original_name,
             "cloned_channel_id": int(ch.id),
-            "channel_webhook_url": url,
+            "channel_webhook_url": None,
             "original_parent_category_id": (
                 int(parent_id) if parent_id is not None else None
             ),
@@ -4203,7 +4198,20 @@ class ServerReceiver:
             chan_ids={int(original_id)}, thread_parent_ids={int(original_id)}
         )
         self._unmapped_warned.discard(int(original_id))
-        return int(original_id), int(ch.id), str(url)
+
+        if clone_messages:
+            self._pending_webhook_channels.setdefault(int(guild.id), []).append({
+                "original_id": int(original_id),
+                "original_name": original_name,
+                "cloned_channel_id": int(ch.id),
+                "parent_id": int(parent_id) if parent_id is not None else None,
+                "cloned_parent_id": int(category.id) if category else None,
+                "channel_type": int(channel_type),
+                "host_guild_id": int(host_guild_id) if host_guild_id is not None else None,
+                "cloned_guild_id": int(guild.id),
+            })
+
+        return int(original_id), int(ch.id), ""
 
     async def _ensure_stage_channel_and_webhook(
         self,
@@ -4263,23 +4271,16 @@ class ServerReceiver:
 
             if ch:
                 if not wh_url and clone_messages:
-                    wh = await self._create_webhook_safely(
-                        ch, "Copycord", await self._get_default_avatar_bytes()
-                    )
-                    wh_url = f"https://discord.com/api/webhooks/{wh.id}/{wh.token}"
-                    self.db.upsert_channel_mapping(
-                        int(original_id),
-                        original_name,
-                        int(clone_id),
-                        wh_url,
-                        int(parent_id) if parent_id is not None else None,
-                        int(category.id) if category else None,
-                        int(channel_type),
-                        original_guild_id=(
-                            int(host_guild_id) if host_guild_id is not None else None
-                        ),
-                        cloned_guild_id=int(guild.id),
-                    )
+                    self._pending_webhook_channels.setdefault(int(guild.id), []).append({
+                        "original_id": int(original_id),
+                        "original_name": original_name,
+                        "cloned_channel_id": int(clone_id),
+                        "parent_id": int(parent_id) if parent_id is not None else None,
+                        "cloned_parent_id": int(category.id) if category else None,
+                        "channel_type": int(channel_type),
+                        "host_guild_id": int(host_guild_id) if host_guild_id is not None else None,
+                        "cloned_guild_id": int(guild.id),
+                    })
 
                 per[int(original_id)] = {
                     "original_channel_id": int(original_id),
@@ -4336,9 +4337,6 @@ class ServerReceiver:
 
         if stage_changes:
             try:
-                await self.ratelimit.acquire_for_guild(
-                    ActionType.EDIT_CHANNEL, guild.id
-                )
                 await ch.edit(**stage_changes)
                 logger.info(
                     "[🎭] Set stage properties for '%s' #%d: %s",
@@ -4353,18 +4351,11 @@ class ServerReceiver:
                     e,
                 )
 
-        url = None
-        if clone_messages:
-            wh = await self._create_webhook_safely(
-                ch, "Copycord", await self._get_default_avatar_bytes()
-            )
-            url = f"https://discord.com/api/webhooks/{wh.id}/{wh.token}"
-
         self.db.upsert_channel_mapping(
             int(original_id),
             original_name,
             int(ch.id),
-            url,
+            None,
             int(parent_id) if parent_id is not None else None,
             int(category.id) if category else None,
             int(channel_type),
@@ -4376,7 +4367,7 @@ class ServerReceiver:
             "original_channel_id": int(original_id),
             "original_channel_name": original_name,
             "cloned_channel_id": int(ch.id),
-            "channel_webhook_url": url,
+            "channel_webhook_url": None,
             "original_parent_category_id": (
                 int(parent_id) if parent_id is not None else None
             ),
@@ -4391,7 +4382,20 @@ class ServerReceiver:
             chan_ids={int(original_id)}, thread_parent_ids={int(original_id)}
         )
         self._unmapped_warned.discard(int(original_id))
-        return int(original_id), int(ch.id), str(url)
+
+        if clone_messages:
+            self._pending_webhook_channels.setdefault(int(guild.id), []).append({
+                "original_id": int(original_id),
+                "original_name": original_name,
+                "cloned_channel_id": int(ch.id),
+                "parent_id": int(parent_id) if parent_id is not None else None,
+                "cloned_parent_id": int(category.id) if category else None,
+                "channel_type": int(channel_type),
+                "host_guild_id": int(host_guild_id) if host_guild_id is not None else None,
+                "cloned_guild_id": int(guild.id),
+            })
+
+        return int(original_id), int(ch.id), ""
 
     async def _sync_channels(
         self,
@@ -4604,9 +4608,6 @@ class ServerReceiver:
 
                 if ctype == ChannelType.news.value:
                     if "NEWS" in guild.features and ch.type != ChannelType.news:
-                        await self.ratelimit.acquire_for_guild(
-                            ActionType.EDIT_CHANNEL, guild.id
-                        )
                         await ch.edit(type=ChannelType.news)
                         converted += 1
                         logger.info(
@@ -4769,9 +4770,6 @@ class ServerReceiver:
                     )
 
                     if clone_ch and getattr(self.config, "DELETE_THREADS", False):
-                        await self.ratelimit.acquire_for_guild(
-                            ActionType.DELETE_CHANNEL, guild.id
-                        )
                         await clone_ch.delete()
                         logger.info("[🗑️] Deleted cloned thread %s", clone_id)
                         await self._emit_event_log(
@@ -4819,9 +4817,6 @@ class ServerReceiver:
             ch = guild.get_channel(cloned_id)
             if ch and ch.name != src["name"]:
                 old = ch.name
-                await self.ratelimit.acquire_for_guild(
-                    ActionType.EDIT_CHANNEL, guild.id
-                )
                 await ch.edit(name=src["name"])
                 self.db.upsert_forum_thread_mapping(
                     orig_thread_id=src_id_int,
@@ -5102,10 +5097,8 @@ class ServerReceiver:
             category = None
 
         if kind == "forum":
-            await self.ratelimit.acquire_for_guild(ActionType.CREATE_CHANNEL, guild.id)
             ch = await guild.create_forum_channel(name=name, category=category)
         elif kind == "voice":
-            await self.ratelimit.acquire_for_guild(ActionType.CREATE_CHANNEL, guild.id)
             ch = await guild.create_voice_channel(name=name, category=category)
         elif kind == "stage":
             if "COMMUNITY" not in guild.features:
@@ -5116,17 +5109,12 @@ class ServerReceiver:
                 )
                 return None
             else:
-                await self.ratelimit.acquire_for_guild(
-                    ActionType.CREATE_CHANNEL, guild.id
-                )
-
                 ch = await guild.create_stage_channel(
                     name=name,
                     topic=topic if topic else "Stage Channel",
                     category=category,
                 )
         else:
-            await self.ratelimit.acquire_for_guild(ActionType.CREATE_CHANNEL, guild.id)
             ch = await guild.create_text_channel(name=name, category=category)
 
         logger.info("[➕] Created %s channel '%s' #%s", kind, name, ch.id)
@@ -5144,9 +5132,6 @@ class ServerReceiver:
         if kind == "news":
             if "NEWS" in guild.features:
                 try:
-                    await self.ratelimit.acquire_for_guild(
-                        ActionType.EDIT_CHANNEL, guild.id
-                    )
                     await ch.edit(type=ChannelType.news)
                     logger.info("[✏️] Converted '%s' #%d to Announcement", name, ch.id)
                     await self._emit_event_log(
@@ -5257,7 +5242,6 @@ class ServerReceiver:
 
             old_name = ch.name
 
-            await self.ratelimit.acquire_for_guild(ActionType.EDIT_CHANNEL, ch.guild.id)
             await ch.edit(name=target)
 
             if has_pin:
@@ -5356,9 +5340,6 @@ class ServerReceiver:
                 try:
                     for ch in list(getattr(clone_cat, "channels", []) or []):
                         try:
-                            await self.ratelimit.acquire_for_guild(
-                                ActionType.DELETE_CHANNEL, guild.id
-                            )
                             await ch.delete()
                             logger.info(
                                 "[🗑️] Deleted channel %s in removed category %s",
@@ -5391,9 +5372,6 @@ class ServerReceiver:
 
             if clone_cat and delete_channels:
                 try:
-                    await self.ratelimit.acquire_for_guild(
-                        ActionType.DELETE_CHANNEL, guild.id
-                    )
                     await clone_cat.delete()
                     logger.info(
                         "[🗑️] Deleted category %s (id=%s) for clone %s",
@@ -5562,9 +5540,6 @@ class ServerReceiver:
                     )
                     mappings_only_here = True
                 else:
-                    await self.ratelimit.acquire_for_guild(
-                        ActionType.DELETE_CHANNEL, guild.id
-                    )
                     try:
                         await ch.delete()
                         logger.info("[🗑️] Deleted channel #%s (%d)", ch.name, ch.id)
@@ -5681,9 +5656,6 @@ class ServerReceiver:
             if not desired or current == desired:
                 return False, "skipped_already_ok"
 
-            await self.ratelimit.acquire_for_guild(
-                ActionType.EDIT_CHANNEL, cat.guild.id
-            )
             await cat.edit(
                 name=desired, reason="Copycord: apply pinned/or upstream category name"
             )
@@ -5809,7 +5781,6 @@ class ServerReceiver:
                     self.cat_map[int(original_id)] = dict(entry)
                     return cat, False
 
-        await self.ratelimit.acquire_for_guild(ActionType.CREATE_CHANNEL, guild.id)
         cat = await guild.create_category(name)
         logger.info("[➕] Created category '%s' #%d", name, cat.id)
         await self._emit_event_log(
@@ -5849,15 +5820,12 @@ class ServerReceiver:
             return
         gate = self._get_webhook_gate(int(ch.guild.id))
         async with gate:
-            await self.ratelimit.acquire_for_guild(
-                ActionType.WEBHOOK_CREATE, ch.guild.id
-            )
             try:
                 await self._get_default_avatar_bytes()
             except Exception:
                 pass
             webhook = await ch.create_webhook(name=name, avatar=avatar_bytes)
-            logger.info("[➕] Created webhook '%s' in channel #%s", name, ch.id)
+            logger.debug("Created webhook '%s' in channel #%s", name, ch.id)
             await self._emit_event_log(
                 "webhook_created",
                 f"Created webhook in #{getattr(ch, 'name', ch.id)}",
@@ -5869,6 +5837,72 @@ class ServerReceiver:
             if hasattr(self, "_wh_meta"):
                 self._wh_meta.clear()
             return webhook
+
+    async def _create_pending_webhooks(self, pending: list[dict]):
+        """
+        Background task: create webhooks for channels that were synced without one.
+        Runs after structure sync completes so channel/category creation isn't blocked.
+        discord.py handles rate limits natively via Retry-After headers.
+        """
+        if not pending:
+            return
+
+        logger.info(
+            "[🔗] Creating webhooks for %d channels in background...", len(pending)
+        )
+        created = 0
+        for entry in pending:
+            if self._shutting_down:
+                break
+            try:
+                clone_gid = entry["cloned_guild_id"]
+                guild = self.bot.get_guild(clone_gid)
+                if not guild:
+                    continue
+                ch = guild.get_channel(entry["cloned_channel_id"])
+                if not ch:
+                    continue
+
+                wh = await self._create_webhook_safely(
+                    ch, "Copycord", await self._get_default_avatar_bytes()
+                )
+                if not wh or not getattr(wh, "id", None):
+                    continue
+
+                url = f"https://discord.com/api/webhooks/{wh.id}/{wh.token}"
+
+                self.db.upsert_channel_mapping(
+                    entry["original_id"],
+                    entry["original_name"],
+                    entry["cloned_channel_id"],
+                    url,
+                    entry.get("parent_id"),
+                    entry.get("cloned_parent_id"),
+                    entry["channel_type"],
+                    original_guild_id=entry.get("host_guild_id"),
+                    cloned_guild_id=clone_gid,
+                )
+
+                for cache in (self.chan_map, self.chan_map_by_clone.get(clone_gid, {})):
+                    row = cache.get(entry["original_id"])
+                    if row and isinstance(row, dict):
+                        row["channel_webhook_url"] = url
+
+                created += 1
+                if created < len(pending):
+                    await asyncio.sleep(1.5)
+            except Exception:
+                logger.exception(
+                    "[⚠️] Failed to create webhook for channel %s (clone ch %s)",
+                    entry.get("original_name"),
+                    entry.get("cloned_channel_id"),
+                )
+
+        logger.info(
+            "[✅] Background webhook creation done: %d/%d created", created, len(pending)
+        )
+        self._load_mappings()
+        return f"Webhooks: Created {created}/{len(pending)}" if created else ""
 
     async def _ensure_channel_and_webhook(
         self,
@@ -5912,23 +5946,16 @@ class ServerReceiver:
 
             if ch:
                 if not wh_url and clone_messages:
-                    wh = await self._create_webhook_safely(
-                        ch, "Copycord", await self._get_default_avatar_bytes()
-                    )
-                    wh_url = f"https://discord.com/api/webhooks/{wh.id}/{wh.token}"
-                    self.db.upsert_channel_mapping(
-                        int(original_id),
-                        original_name,
-                        int(clone_id),
-                        wh_url,
-                        int(parent_id) if parent_id is not None else None,
-                        int(category.id) if category else None,
-                        int(channel_type),
-                        original_guild_id=(
-                            int(host_guild_id) if host_guild_id is not None else None
-                        ),
-                        cloned_guild_id=int(guild.id),
-                    )
+                    self._pending_webhook_channels.setdefault(int(guild.id), []).append({
+                        "original_id": int(original_id),
+                        "original_name": original_name,
+                        "cloned_channel_id": int(clone_id),
+                        "parent_id": int(parent_id) if parent_id is not None else None,
+                        "cloned_parent_id": int(category.id) if category else None,
+                        "channel_type": int(channel_type),
+                        "host_guild_id": int(host_guild_id) if host_guild_id is not None else None,
+                        "cloned_guild_id": int(guild.id),
+                    })
 
                 per[int(original_id)] = {
                     "original_channel_id": int(original_id),
@@ -5964,18 +5991,11 @@ class ServerReceiver:
         kind = "news" if int(channel_type) == discord.ChannelType.news.value else "text"
         ch = await self._create_channel(guild, kind, original_name, category)
 
-        url = None
-        if clone_messages:
-            wh = await self._create_webhook_safely(
-                ch, "Copycord", await self._get_default_avatar_bytes()
-            )
-            url = f"https://discord.com/api/webhooks/{wh.id}/{wh.token}"
-
         self.db.upsert_channel_mapping(
             int(original_id),
             original_name,
             int(ch.id),
-            url,
+            None,
             int(parent_id) if parent_id is not None else None,
             int(category.id) if category else None,
             int(channel_type),
@@ -5987,7 +6007,7 @@ class ServerReceiver:
             "original_channel_id": int(original_id),
             "original_channel_name": original_name,
             "cloned_channel_id": int(ch.id),
-            "channel_webhook_url": url,
+            "channel_webhook_url": None,
             "original_parent_category_id": (
                 int(parent_id) if parent_id is not None else None
             ),
@@ -6002,7 +6022,20 @@ class ServerReceiver:
             chan_ids={int(original_id)}, thread_parent_ids={int(original_id)}
         )
         self._unmapped_warned.discard(int(original_id))
-        return int(original_id), int(ch.id), str(url)
+
+        if clone_messages:
+            self._pending_webhook_channels.setdefault(int(guild.id), []).append({
+                "original_id": int(original_id),
+                "original_name": original_name,
+                "cloned_channel_id": int(ch.id),
+                "parent_id": int(parent_id) if parent_id is not None else None,
+                "cloned_parent_id": int(category.id) if category else None,
+                "channel_type": int(channel_type),
+                "host_guild_id": int(host_guild_id) if host_guild_id is not None else None,
+                "cloned_guild_id": int(guild.id),
+            })
+
+        return int(original_id), int(ch.id), ""
 
     async def _handle_master_channel_moves(
         self,
@@ -6109,9 +6142,6 @@ class ServerReceiver:
                 continue
 
             try:
-                await self.ratelimit.acquire_for_guild(
-                    ActionType.EDIT_CHANNEL, guild.id
-                )
                 await ch.edit(category=desired_parent)
                 moved += 1
                 old_name = actual_parent_name or "standalone"
@@ -6340,8 +6370,8 @@ class ServerReceiver:
                     cloned_guild_id=guild.id,
                 )
 
-                logger.info(
-                    "[➕] Recreated missing webhook for channel `%s` #%s",
+                logger.debug(
+                    "Created on-demand webhook for channel `%s` #%s",
                     fresh["original_channel_name"],
                     original_id,
                 )
@@ -8686,8 +8716,8 @@ class ServerReceiver:
                             self._pending_msgs.setdefault(source_id, []).append(msg)
                             continue
 
-                        logger.warning(
-                            "[⚠️] Mapped channel %s has no webhook (clone ch=%s); attempting to recreate",
+                        logger.debug(
+                            "Mapped channel %s has no webhook (clone ch=%s); creating on demand",
                             msg.get("channel_name"),
                             clone_cid,
                         )
@@ -9506,22 +9536,30 @@ class ServerReceiver:
                     )
                     if not webhook_url:
                         try:
-                            primary = mrow.get("channel_webhook_url") or mrow.get(
-                                "webhook_url"
-                            )
-                            webhook_url, _ = await self.backfill.pick_url_for_send(
-                                int(cloned_id),
-                                primary_url=primary,
-                                create_missing=True,
-                            )
-                        except Exception:
-
                             webhook_url = await self._recreate_webhook(
                                 int(parent_id), int(data.get("guild_id") or 0)
                             )
+                        except Exception:
+                            logger.debug(
+                                "On-demand webhook creation failed for thread parent %s",
+                                parent_id,
+                                exc_info=True,
+                            )
+                        if not webhook_url:
+                            try:
+                                primary = mrow.get("channel_webhook_url") or mrow.get(
+                                    "webhook_url"
+                                )
+                                webhook_url, _ = await self.backfill.pick_url_for_send(
+                                    int(cloned_id),
+                                    primary_url=primary,
+                                    create_missing=True,
+                                )
+                            except Exception:
+                                pass
                 if not webhook_url:
-                    logger.warning(
-                        "[⚠️] No webhook for parent %s in clone_g=%s; queueing thread msg",
+                    logger.debug(
+                        "No webhook for parent %s in clone_g=%s; queueing thread msg",
                         parent_id,
                         guild.id,
                     )
@@ -12057,9 +12095,6 @@ class ServerReceiver:
                 await ws.stop()
         except Exception:
             logger.debug("[shutdown] ws stop failed", exc_info=True)
-        finally:
-            logger.info("Server shutdown complete.")
-
         async def _cancel_and_wait(task, name: str):
             if not task:
                 return
@@ -12117,6 +12152,10 @@ class ServerReceiver:
 
         try:
             loop.run_until_complete(self.bot.start(self.config.SERVER_TOKEN))
+        except (KeyboardInterrupt, RuntimeError) as e:
+            if not self._shutting_down:
+                raise
+            logger.debug("Suppressed expected error during shutdown: %s", e)
         finally:
             pending = asyncio.all_tasks(loop=loop)
             for task in pending:
@@ -12125,7 +12164,7 @@ class ServerReceiver:
 
 
 def _autostart_enabled() -> bool:
-    return os.getenv("COPYCORD_AUTOSTART", "true").lower() in ("1", "true", "yes", "on")
+    return os.getenv("COPYCORD_AUTOSTART", "false").lower() in ("1", "true", "yes", "on")
 
 
 if __name__ == "__main__":

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -8482,11 +8482,12 @@ class ServerReceiver:
             bf_targets = _bf_targets_for_source(source_id)
 
         if not rows:
-
+            msg["__buffered__"] = True
+            self._pending_msgs.setdefault(source_id, []).append(msg)
             async with self._warn_lock:
                 if source_id not in self._unmapped_warned:
                     logger.debug(
-                        "[🚫] No mapping for channel %s (%s); dropping message from %s",
+                        "[⌛] No mapping yet for channel %s (%s); queued message from %s",
                         msg.get("channel_name"),
                         msg.get("channel_id"),
                         msg.get("author"),

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -7827,10 +7827,12 @@ class ServerReceiver:
 
             if not rows:
                 try:
-                    rows = list(
-                        self.db.get_channel_mappings_for_original(origin_channel_id)
-                        or []
-                    )
+                    rows = [
+                        dict(r) for r in (
+                            self.db.get_channel_mappings_for_original(origin_channel_id)
+                            or []
+                        )
+                    ]
                 except Exception:
                     rows = []
             return rows
@@ -8707,7 +8709,7 @@ class ServerReceiver:
 
                         lock = self._guild_sync_locks.get(clone_gid)
                         if lock and lock.locked():
-                            logger.info(
+                            logger.debug(
                                 "[⌛] Sync in progress; message in #%s from %s is queued and will be sent after sync",
                                 msg.get("channel_name"),
                                 msg.get("author"),
@@ -8996,8 +8998,8 @@ class ServerReceiver:
                 continue
 
         if not allowed:
-            logger.info(
-                "[✏️] Edited message not resent — EDIT_MESSAGES or RESEND_EDITED_MESSAGES is disabled for all clones of channel %s",
+            logger.debug(
+                "Edited message not resent — EDIT_MESSAGES or RESEND_EDITED_MESSAGES is disabled for all clones of channel %s",
                 source_id,
             )
             return

--- a/code/server/stickers.py
+++ b/code/server/stickers.py
@@ -190,7 +190,7 @@ class StickerManager:
         stickers = st["sitemap"] or []
 
         async def _run_one():
-            await self._run_sync(
+            return await self._run_sync(
                 guild=guild,
                 stickers=stickers,
                 host_id=host_id,
@@ -266,6 +266,9 @@ class StickerManager:
                         guild_id=guild.id,
                         guild_name=getattr(guild, "name", None),
                     )
+                    return f"Stickers: {summary_text}"
+                else:
+                    return ""
 
             except asyncio.CancelledError:
                 self._log("debug", "[🎟️] Sticker sync canceled before completion.")

--- a/code/server/stickers.py
+++ b/code/server/stickers.py
@@ -341,6 +341,7 @@ class StickerManager:
                         f"Deleted sticker '{row['cloned_sticker_name']}'",
                         guild_id=guild.id,
                         guild_name=getattr(guild, "name", None),
+                        extra={"original_sticker_id": int(orig_id), "clone_sticker_id": int(row["cloned_sticker_id"])},
                     )
 
                 except discord.Forbidden:
@@ -405,6 +406,7 @@ class StickerManager:
                         f"Renamed sticker '{mapping['original_sticker_name']}' → '{name}'",
                         guild_id=guild.id,
                         guild_name=getattr(guild, "name", None),
+                        extra={"original_sticker_id": int(orig_id), "clone_sticker_id": int(cloned.id)},
                     )
 
                 except discord.HTTPException as e:
@@ -499,16 +501,18 @@ class StickerManager:
                     f"Created sticker '{name}'",
                     guild_id=guild.id,
                     guild_name=getattr(guild, "name", None),
+                    extra={"original_sticker_id": int(orig_id), "clone_sticker_id": int(created_stk.id)},
                 )
 
             except discord.HTTPException as e:
 
                 if getattr(e, "code", None) == 30039 or "30039" in str(e):
-                    skipped_limit += 1
                     self._log(
-                        "info",
-                        "[🎟️] Skipped creating sticker due to clone guild sticker limit.",
+                        "warning",
+                        "[🎟️] Sticker limit reached; stopping sticker sync (%d created so far)",
+                        created,
                     )
+                    break
 
                 else:
                     self._log(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   admin:
-    image: ghcr.io/copycord/copycord:v3.19.0
+    image: ghcr.io/copycord/copycord:v3.20.0
     container_name: copycord-admin
     environment:
       - ROLE=admin
@@ -11,7 +11,7 @@ services:
       - ./data:/data
 
   server:
-    image: ghcr.io/copycord/copycord:v3.19.0
+    image: ghcr.io/copycord/copycord:v3.20.0
     container_name: copycord-server
     environment:
       - ROLE=server
@@ -21,7 +21,7 @@ services:
       - admin
 
   client:
-    image: ghcr.io/copycord/copycord:v3.19.0
+    image: ghcr.io/copycord/copycord:v3.20.0
     container_name: copycord-client
     environment:
       - ROLE=client

--- a/website/docs/configuration/advanced.md
+++ b/website/docs/configuration/advanced.md
@@ -100,9 +100,9 @@ Copycord automatically prunes log files to prevent them from growing indefinitel
 - Default: `10` MB
 - Set to `0` to disable pruning
 - Checks run every 5 minutes
-- Applies to both `server.log` and `client.log`
+- Applies to `server.out` and `client.out`
 
-When a log file exceeds the limit, older entries are trimmed while preserving the most recent logs.
+The pruner uses memory-efficient seek-based reading — only the tail of the file is loaded into memory, even for very large log files. Writes are atomic (via temp file) to prevent data loss.
 
 ## Rate limit behavior
 

--- a/website/docs/configuration/advanced.md
+++ b/website/docs/configuration/advanced.md
@@ -83,18 +83,31 @@ DATA_DIR=/custom/path
 Make sure the directory exists and is writable. For Docker, mount the appropriate volume.
 :::
 
+## Auto-start
+
+By default, Copycord does not automatically start the server and client bots when it launches. To enable auto-start:
+
+1. Go to **Global Configuration** in the dashboard
+2. Set **AUTO_START** to `True`
+3. Click **Save**
+
+On the next launch, Copycord will validate your tokens and start both bots automatically if they are valid.
+
+## Log pruning
+
+Copycord automatically prunes log files to prevent them from growing indefinitely. Configure the maximum size via **MAX_LOG_SIZE_MB** in Global Configuration:
+
+- Default: `10` MB
+- Set to `0` to disable pruning
+- Checks run every 5 minutes
+- Applies to both `server.log` and `client.log`
+
+When a log file exceeds the limit, older entries are trimmed while preserving the most recent logs.
+
 ## Rate limit behavior
 
-Copycord has built-in rate limiters that respect Discord's API limits:
+Copycord relies on discord.py's native rate limit handling for structure sync operations (channel creation, editing, role operations, etc.). When Discord returns a `429 Too Many Requests` response, the library automatically waits the required `Retry-After` duration before retrying.
 
-| Action | Rate | Notes |
-|--------|------|-------|
-| Webhook messages | 5 per 2.5s | Per webhook |
-| Channel creation | 2 per 15s | Per guild |
-| Webhook creation | 1 per 30s | Per guild |
-| Channel editing | 3 per 15s | Per guild |
-| Role operations | 1 per 10s | Per guild |
-| Emoji operations | 1 per 60s | Per guild |
-| Sticker operations | 1 per 60s | Per guild |
+For webhook message sending, Copycord uses a lightweight rate limiter (5 per 2.5s per webhook) to stay within Discord's message rate limits.
 
-These limits are handled automatically. If you're using proxies, some limits can be relaxed.
+If you're using proxies, requests are distributed across different IPs, allowing higher throughput.

--- a/website/docs/configuration/cloning-options.md
+++ b/website/docs/configuration/cloning-options.md
@@ -13,6 +13,7 @@ These settings control what Copycord syncs between the source and clone servers.
 |--------|---------|-------------|
 | `ENABLE_CLONING` | `true` | Master switch — disables all cloning when off |
 | `CLONE_MESSAGES` | `true` | Clone messages in real time via webhooks. When disabled, webhook creation is also skipped during sync |
+| `ON_DEMAND_WEBHOOKS` | `true` | When enabled, webhooks are only created when a channel receives its first message instead of during sync. This makes server cloning much faster by skipping upfront webhook creation |
 
 ## Message sync
 

--- a/website/docs/dashboard/backfill.md
+++ b/website/docs/dashboard/backfill.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: History Import (Backfill)
 ---
 

--- a/website/docs/dashboard/backups.md
+++ b/website/docs/dashboard/backups.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 title: Backups
 ---
 

--- a/website/docs/dashboard/channels.md
+++ b/website/docs/dashboard/channels.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: Channels
 ---
 

--- a/website/docs/dashboard/filters.md
+++ b/website/docs/dashboard/filters.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: Filters
 ---
 

--- a/website/docs/dashboard/forwarding.md
+++ b/website/docs/dashboard/forwarding.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: Message Forwarding
 ---
 

--- a/website/docs/dashboard/guild-mappings.md
+++ b/website/docs/dashboard/guild-mappings.md
@@ -43,6 +43,42 @@ Copycord supports multiple guild mappings simultaneously. You can:
 
 Each mapping operates independently with its own filters and settings.
 
+## Export messages
+
+The Guilds page includes a message export tool. Click the **export** button on any guild card to open the export modal.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| **Channel ID** | Export only a specific channel (leave blank for all channels) |
+| **Filter by User ID** | Export only messages from a specific user |
+| **Forward to webhook** | Send each exported message to a Discord webhook in real time |
+| **Date Range** | Filter by "After" and "Before" dates |
+| **Download media** | Save attachments locally (images, videos, audio, other files) |
+
+### Filters
+
+The **Filters** section lets you narrow down which messages are exported:
+
+- Content types: text, embeds, attachments, links, emojis, stickers, mentions
+- Attachment types: images, videos, audio, other
+- Message types: replies, bot messages, system messages, pinned messages
+- Thread types: threads, forum threads, private threads
+- Keyword search: include only messages containing a specific word
+- Minimum message length and minimum total reactions
+
+### Output
+
+- **JSON file** — Saved to `/data/exports/<guild_id>/<timestamp>/messages.json` with all matched messages
+- **Webhook forwarding** — Each message is forwarded to the provided webhook URL with a small delay between sends
+- **Media files** — Downloaded attachments are organized by type in `/data/exports/<guild_id>/<timestamp>/media/`
+
+:::info
+Only one export per guild can run at a time. Exports run asynchronously — you can close the modal and the export continues in the background.
+:::
+
+
 ## How syncing works
 
 When a mapping is active, Copycord continuously:

--- a/website/docs/dashboard/guild-mappings.md
+++ b/website/docs/dashboard/guild-mappings.md
@@ -43,42 +43,6 @@ Copycord supports multiple guild mappings simultaneously. You can:
 
 Each mapping operates independently with its own filters and settings.
 
-## Export messages
-
-The Guilds page includes a message export tool. Click the **export** button on any guild card to open the export modal.
-
-### Options
-
-| Option | Description |
-|--------|-------------|
-| **Channel ID** | Export only a specific channel (leave blank for all channels) |
-| **Filter by User ID** | Export only messages from a specific user |
-| **Forward to webhook** | Send each exported message to a Discord webhook in real time |
-| **Date Range** | Filter by "After" and "Before" dates |
-| **Download media** | Save attachments locally (images, videos, audio, other files) |
-
-### Filters
-
-The **Filters** section lets you narrow down which messages are exported:
-
-- Content types: text, embeds, attachments, links, emojis, stickers, mentions
-- Attachment types: images, videos, audio, other
-- Message types: replies, bot messages, system messages, pinned messages
-- Thread types: threads, forum threads, private threads
-- Keyword search: include only messages containing a specific word
-- Minimum message length and minimum total reactions
-
-### Output
-
-- **JSON file** — Saved to `/data/exports/<guild_id>/<timestamp>/messages.json` with all matched messages
-- **Webhook forwarding** — Each message is forwarded to the provided webhook URL with a small delay between sends
-- **Media files** — Downloaded attachments are organized by type in `/data/exports/<guild_id>/<timestamp>/media/`
-
-:::info
-Only one export per guild can run at a time. Exports run asynchronously — you can close the modal and the export continues in the background.
-:::
-
-
 ## How syncing works
 
 When a mapping is active, Copycord continuously:

--- a/website/docs/dashboard/guilds.md
+++ b/website/docs/dashboard/guilds.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 3
+title: Guilds
+---
+
+# Guilds
+
+The **Guilds** page lists all Discord servers your self-bot (client) is a member of. Both the **server** and **client** bots must be running for this page to load — if either is stopped, the guild list will be empty.
+
+## Server list
+
+The page displays a card for each guild your self-bot account is in, showing the server name and icon.
+
+Click on any guild card to see two options:
+
+- **View Details** — Opens a popup with guild information (server name, member count, owner ID)
+- **Export Messages** — Opens the export modal to extract messages from that server
+
+## Export messages
+
+The export tool extracts messages from a source server with granular filtering options.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| **Channel ID** | Export only a specific channel (leave blank for all channels) |
+| **Filter by User ID** | Export only messages from a specific user |
+| **Forward to webhook** | Send each exported message to a Discord webhook in real time |
+| **Date Range** | Filter by "After" and "Before" dates |
+| **Download media** | Save attachments locally (images, videos, audio, other files) |
+
+### Filters
+
+The **Filters** section lets you narrow down which messages are exported:
+
+- Content types: text, embeds, attachments, links, emojis, stickers, mentions
+- Attachment types: images, videos, audio, other
+- Message types: replies, bot messages, system messages, pinned messages
+- Thread types: threads, forum threads, private threads
+- Keyword search: include only messages containing a specific word
+- Minimum message length and minimum total reactions
+
+### Output
+
+- **JSON file** — Saved to `/data/exports/<guild_id>/<timestamp>/messages.json` with all matched messages
+- **Webhook forwarding** — Each message is forwarded to the provided webhook URL with a small delay between sends
+- **Media files** — Downloaded attachments are organized by type in `/data/exports/<guild_id>/<timestamp>/media/`
+
+:::info
+Only one export per guild can run at a time. Exports run asynchronously — you can close the modal and the export continues in the background.
+:::

--- a/website/docs/dashboard/overview.md
+++ b/website/docs/dashboard/overview.md
@@ -46,6 +46,26 @@ The dashboard provides **Start** and **Stop** buttons for both the server and cl
 - **Server** (green indicator) — The Discord bot in your clone server
 - **Client** (green indicator) — The self-bot monitoring source servers
 
+Valid tokens are required to start.
+
+## Global configuration
+
+The Global Configuration card lets you set core settings:
+
+- **SERVER_TOKEN** / **CLIENT_TOKEN** — Your Discord bot and account tokens
+- **COMMAND_USERS** — User IDs allowed to run slash commands
+- **LOG_LEVEL** — `INFO` or `DEBUG`
+- **AUTO_START** — Automatically start bots when Copycord launches (requires valid tokens)
+- **MAX_LOG_SIZE_MB** — Maximum log file size before old entries are pruned (default: 10 MB, set to 0 to disable)
+
+## Log viewer
+
+Click **View server logs** or **View client logs** on the Bots card to open the log viewer. Features:
+
+- Real-time log streaming
+- Search/filter logs
+- **Clear logs** button to wipe the selected log file (with confirmation)
+
 ## Real-time updates
 
 The dashboard uses WebSocket connections for real-time updates. You'll see live status changes, log streaming, and operation progress without needing to refresh the page.

--- a/website/docs/dashboard/overview.md
+++ b/website/docs/dashboard/overview.md
@@ -18,18 +18,17 @@ The main dashboard page gives you an at-a-glance view of your entire setup:
 
 ## Navigation
 
-The dashboard is organized into these pages:
+The dashboard sidebar has these pages:
 
 | Page | Purpose |
 |------|---------|
-| **Dashboard** | Main control center — status, mappings, start/stop |
-| **Guilds** | Create and manage source → clone server mappings |
-| **Channels** | View and customize cloned channel names |
-| **Filters** | Configure channel/category whitelist and exclusion filters |
+| **Configuration** | Bot status, global config, guild mappings, start/stop |
+| **Channels** | View and customize cloned channel names, orphan detection, backfill |
+| **Guilds** | Browse all servers your self-bot is in, export messages |
 | **Forwarding** | Set up message forwarding to Telegram, Pushover, etc. |
 | **Scraper** | Member scraper tool for exporting user data |
-| **System** | System settings, logs, database backups, configuration |
-| **Event Logs** | Browse the activity/audit log |
+| **System** | Version info, database backups |
+| **Logs** | Event logs  |
 
 ## Authentication
 

--- a/website/docs/dashboard/scraper.md
+++ b/website/docs/dashboard/scraper.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: Member Scraper
 ---
 

--- a/website/docs/dashboard/system.md
+++ b/website/docs/dashboard/system.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 title: System
 ---
 

--- a/website/docs/dashboard/system.md
+++ b/website/docs/dashboard/system.md
@@ -22,7 +22,11 @@ The system page provides access to application logs:
 - **Client logs** — Activity from the self-bot (message detection, event handling)
 - **Scraper logs** — Member scraper activity
 
-Logs stream in real time and can be cleared as needed.
+Logs stream in real time. Each log viewer has its own **Clear logs** button to wipe that specific log file.
+
+### Log pruning
+
+Copycord automatically prunes log files to prevent them from growing indefinitely. Configure the maximum log file size via the **MAX_LOG_SIZE_MB** setting in Global Configuration (default: 10 MB). Set to 0 to disable pruning. The pruner checks log file sizes every 5 minutes and trims older entries when a file exceeds the limit.
 
 ## Event logs
 

--- a/website/docs/dashboard/system.md
+++ b/website/docs/dashboard/system.md
@@ -32,13 +32,19 @@ Copycord automatically prunes log files to prevent them from growing indefinitel
 
 The **Event Logs** page provides a structured audit trail of all Copycord operations:
 
-- Message forwarding events
-- Structure sync events (channel/role creation, deletion, rename)
-- Backfill progress
+- Structure sync events (channel/role/emoji/sticker creation, deletion, rename)
+- Permission sync events
+- Webhook creation events
+- Guild metadata updates
+- Thread operations
 - Error events
-- System events
 
-You can filter by event type, browse pages, and delete individual or bulk entries.
+### Features
+
+- **Filter by type** — Dropdown only shows event types that have actual logs
+- **Expandable rows** — Click any log entry to see detailed metadata (source/clone IDs, sync task ID, category info)
+- **Refresh** — Refresh button to reload the current view
+- **Delete** — Delete individual entries or clear all logs
 
 ## Version information
 

--- a/website/docs/features/message-cloning.md
+++ b/website/docs/features/message-cloning.md
@@ -74,6 +74,7 @@ This hides the real identity of users in the source server.
 
 Copycord uses Discord webhooks to post cloned messages. Webhooks allow messages to appear with custom usernames and avatars, making them look like they were posted by the original author.
 
-- Webhooks are created automatically for each channel
+- By default (`ON_DEMAND_WEBHOOKS: true`), webhooks are created on-demand when a channel receives its first message
+- If `ON_DEMAND_WEBHOOKS` is disabled, webhooks are batch-created in the background after structure sync
 - A webhook pool is maintained for performance
 - Custom webhook identities can be set per-channel via the `/channel_webhook` commands

--- a/website/docs/features/structure-sync.md
+++ b/website/docs/features/structure-sync.md
@@ -81,16 +81,25 @@ The client self-bot receives Discord gateway events for every change in the sour
 
 A comprehensive structure comparison runs periodically (default: every 60 minutes). This catches any changes that might have been missed during downtime or network interruptions.
 
-## Rate limiting
+## Sync architecture
 
-Structure operations are rate-limited to respect Discord's API limits:
+Structure sync is designed to be as fast as possible while respecting Discord's API limits.
 
-| Operation | Rate |
-|-----------|------|
-| Channel creation | 2 per 15 seconds |
-| Channel editing | 3 per 15 seconds |
-| Role operations | 1 per 10 seconds |
-| Emoji operations | 1 per 60 seconds |
-| Sticker operations | 1 per 60 seconds |
+### Two-phase channel sync
 
-Copycord queues operations and processes them within these limits automatically.
+Channel and category creation runs first without any artificial delays — Discord's built-in rate limit handling (via `Retry-After` headers) is used automatically. Webhook creation is handled separately:
+
+- **`ON_DEMAND_WEBHOOKS: true` (default)** — Webhooks are not created during sync at all. Instead, they are created lazily when the first message arrives for a channel. This makes initial server cloning near-instant for the structure phase.
+- **`ON_DEMAND_WEBHOOKS: false`** — Webhooks are batch-created in the background after structure sync completes, with a small delay between each to avoid hitting rate limits.
+
+### Parallel background tasks
+
+Roles, emojis, and stickers sync in parallel as background tasks while structure sync runs. The sync is only reported as complete once all background tasks have finished.
+
+### Cancel and restart
+
+If a new sitemap arrives while a sync is already running for the same clone guild, the running sync is canceled and a new one starts with the latest data. Background tasks (roles, emojis, stickers, webhooks) from the canceled sync continue running independently — they are not interrupted.
+
+### Rate limiting
+
+Copycord relies on discord.py's native rate limit handling for all structure sync operations. When Discord returns a `429 Too Many Requests` response, the library automatically waits the required `Retry-After` duration before retrying.

--- a/website/docs/features/structure-sync.md
+++ b/website/docs/features/structure-sync.md
@@ -100,6 +100,14 @@ Roles, emojis, and stickers sync in parallel as background tasks while structure
 
 If a new sitemap arrives while a sync is already running for the same clone guild, the running sync is canceled and a new one starts with the latest data. Background tasks (roles, emojis, stickers, webhooks) from the canceled sync continue running independently — they are not interrupted.
 
+### Message buffering
+
+Messages that arrive for channels not yet cloned are automatically queued. Once the sync creates the channel and its webhook (on-demand or batch), buffered messages are replayed in order. No messages are dropped during sync.
+
+### Emoji and sticker limits
+
+When cloning emojis or stickers, if the clone guild hits Discord's limit (e.g., 50 emojis for unboosted servers), the sync stops. The limit is re-evaluated on each sync cycle.
+
 ### Rate limiting
 
-Copycord relies on discord.py's native rate limit handling for all structure sync operations. When Discord returns a `429 Too Many Requests` response, the library automatically waits the required `Retry-After` duration before retrying.
+Copycord uses discord.py's native rate limit handling for all structure sync operations. When Discord returns a `429 Too Many Requests` response, the library automatically waits the required `Retry-After` duration before retrying.

--- a/website/docs/getting-started/docker-install.md
+++ b/website/docs/getting-started/docker-install.md
@@ -52,7 +52,7 @@ Create a file named `docker-compose.yml` with the following content:
 ```yaml
 services:
   admin:
-    image: ghcr.io/copycord/copycord:v3.19.0
+    image: ghcr.io/copycord/copycord:v3.20.0
     container_name: copycord-admin
     environment:
       - ROLE=admin
@@ -64,7 +64,7 @@ services:
     restart: unless-stopped
 
   server:
-    image: ghcr.io/copycord/copycord:v3.19.0
+    image: ghcr.io/copycord/copycord:v3.20.0
     container_name: copycord-server
     environment:
       - ROLE=server
@@ -75,7 +75,7 @@ services:
     restart: unless-stopped
 
   client:
-    image: ghcr.io/copycord/copycord:v3.19.0
+    image: ghcr.io/copycord/copycord:v3.20.0
     container_name: copycord-client
     environment:
       - ROLE=client

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -21,6 +21,19 @@ const config = {
     locales: ['en'],
   },
 
+  themes: [
+    [
+      '@easyops-cn/docusaurus-search-local',
+      /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
+      ({
+        hashed: true,
+        language: ['en'],
+        indexBlog: false,
+        docsRouteBasePath: '/docs',
+      }),
+    ],
+  ],
+
   presets: [
     [
       'classic',

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "^3.6.3",
         "@docusaurus/preset-classic": "^3.6.3",
+        "@easyops-cn/docusaurus-search-local": "^0.55.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.1.0",
         "prism-react-renderer": "^2.3.0",
@@ -4232,6 +4233,156 @@
         "node": ">=18.0"
       }
     },
+    "node_modules/@easyops-cn/autocomplete.js": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/autocomplete.js/-/autocomplete.js-0.38.1.tgz",
+      "integrity": "sha512-drg76jS6syilOUmVNkyo1c7ZEBPcPuK+aJA7AksM5ZIIbV57DMHCywiCr+uHyv8BE5jUTU98j/H7gVrkHrWW3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "immediate": "^3.2.3"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.55.1.tgz",
+      "integrity": "sha512-jmBKj1J+tajqNrCvECwKCQYTWwHVZDGApy8lLOYEPe+Dm0/f3Ccdw8BP5/OHNpltr7WDNY2roQXn+TWn2f1kig==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/plugin-content-docs": "^2 || ^3",
+        "@docusaurus/theme-translations": "^2 || ^3",
+        "@docusaurus/utils": "^2 || ^3",
+        "@docusaurus/utils-common": "^2 || ^3",
+        "@docusaurus/utils-validation": "^2 || ^3",
+        "@easyops-cn/autocomplete.js": "^0.38.1",
+        "@node-rs/jieba": "^1.6.0",
+        "cheerio": "^1.0.0",
+        "clsx": "^2.1.1",
+        "comlink": "^4.4.2",
+        "debug": "^4.2.0",
+        "fs-extra": "^10.0.0",
+        "klaw-sync": "^6.0.0",
+        "lunr": "^2.3.9",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@docusaurus/theme-common": "^2 || ^3",
+        "open-ask-ai": "^0.7.3",
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || 17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "open-ask-ai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -4389,6 +4540,271 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@node-rs/jieba": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba/-/jieba-1.10.4.tgz",
+      "integrity": "sha512-GvDgi8MnBiyWd6tksojej8anIx18244NmIOc1ovEw8WKNUejcccLfyu8vj66LWSuoZuKILVtNsOy4jvg3aoxIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@node-rs/jieba-android-arm-eabi": "1.10.4",
+        "@node-rs/jieba-android-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-x64": "1.10.4",
+        "@node-rs/jieba-freebsd-x64": "1.10.4",
+        "@node-rs/jieba-linux-arm-gnueabihf": "1.10.4",
+        "@node-rs/jieba-linux-arm64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-arm64-musl": "1.10.4",
+        "@node-rs/jieba-linux-x64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-x64-musl": "1.10.4",
+        "@node-rs/jieba-wasm32-wasi": "1.10.4",
+        "@node-rs/jieba-win32-arm64-msvc": "1.10.4",
+        "@node-rs/jieba-win32-ia32-msvc": "1.10.4",
+        "@node-rs/jieba-win32-x64-msvc": "1.10.4"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm-eabi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm-eabi/-/jieba-android-arm-eabi-1.10.4.tgz",
+      "integrity": "sha512-MhyvW5N3Fwcp385d0rxbCWH42kqDBatQTyP8XbnYbju2+0BO/eTeCCLYj7Agws4pwxn2LtdldXRSKavT7WdzNA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm64/-/jieba-android-arm64-1.10.4.tgz",
+      "integrity": "sha512-XyDwq5+rQ+Tk55A+FGi6PtJbzf974oqnpyCcCPzwU3QVXJCa2Rr4Lci+fx8oOpU4plT3GuD+chXMYLsXipMgJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-arm64/-/jieba-darwin-arm64-1.10.4.tgz",
+      "integrity": "sha512-G++RYEJ2jo0rxF9626KUy90wp06TRUjAsvY/BrIzEOX/ingQYV/HjwQzNPRR1P1o32a6/U8RGo7zEBhfdybL6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-x64/-/jieba-darwin-x64-1.10.4.tgz",
+      "integrity": "sha512-MmDNeOb2TXIZCPyWCi2upQnZpPjAxw5ZGEj6R8kNsPXVFALHIKMa6ZZ15LCOkSTsKXVC17j2t4h+hSuyYb6qfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-freebsd-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-freebsd-x64/-/jieba-freebsd-x64-1.10.4.tgz",
+      "integrity": "sha512-/x7aVQ8nqUWhpXU92RZqd333cq639i/olNpd9Z5hdlyyV5/B65LLy+Je2B2bfs62PVVm5QXRpeBcZqaHelp/bg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm-gnueabihf": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm-gnueabihf/-/jieba-linux-arm-gnueabihf-1.10.4.tgz",
+      "integrity": "sha512-crd2M35oJBRLkoESs0O6QO3BBbhpv+tqXuKsqhIG94B1d02RVxtRIvSDwO33QurxqSdvN9IeSnVpHbDGkuXm3g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-gnu/-/jieba-linux-arm64-gnu-1.10.4.tgz",
+      "integrity": "sha512-omIzNX1psUzPcsdnUhGU6oHeOaTCuCjUgOA/v/DGkvWC1jLcnfXe4vdYbtXMh4XOCuIgS1UCcvZEc8vQLXFbXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-musl/-/jieba-linux-arm64-musl-1.10.4.tgz",
+      "integrity": "sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-gnu/-/jieba-linux-x64-gnu-1.10.4.tgz",
+      "integrity": "sha512-WZO8ykRJpWGE9MHuZpy1lu3nJluPoeB+fIJJn5CWZ9YTVhNDWoCF4i/7nxz1ntulINYGQ8VVuCU9LD86Mek97g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-musl/-/jieba-linux-x64-musl-1.10.4.tgz",
+      "integrity": "sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-wasm32-wasi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-wasm32-wasi/-/jieba-wasm32-wasi-1.10.4.tgz",
+      "integrity": "sha512-Y2umiKHjuIJy0uulNDz9SDYHdfq5Hmy7jY5nORO99B4pySKkcrMjpeVrmWXJLIsEKLJwcCXHxz8tjwU5/uhz0A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-arm64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-arm64-msvc/-/jieba-win32-arm64-msvc-1.10.4.tgz",
+      "integrity": "sha512-nwMtViFm4hjqhz1it/juQnxpXgqlGltCuWJ02bw70YUDMDlbyTy3grCJPpQQpueeETcALUnTxda8pZuVrLRcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-ia32-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-ia32-msvc/-/jieba-win32-ia32-msvc-1.10.4.tgz",
+      "integrity": "sha512-DCAvLx7Z+W4z5oKS+7vUowAJr0uw9JBw8x1Y23Xs/xMA4Em+OOSiaF5/tCJqZUCJ8uC4QeImmgDFiBqGNwxlyA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-x64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-x64-msvc/-/jieba-win32-x64-msvc-1.10.4.tgz",
+      "integrity": "sha512-+sqemSfS1jjb+Tt7InNbNzrRh1Ua3vProVvC4BZRPg010/leCbGFFiQHpzcPRfpxAXZrzG5Y0YBTsPzN/I4yHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4790,6 +5206,16 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -6433,9 +6859,9 @@
       }
     },
     "node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6489,6 +6915,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -7736,6 +8168,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -9663,6 +10120,12 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "9.0.21",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
@@ -10249,6 +10712,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -10427,6 +10899,24 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
+    },
+    "node_modules/lunr-languages": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.14.0.tgz",
+      "integrity": "sha512-hWUAb2KqM3L7J5bcrngszzISY4BxrXn/Xhbb9TTCJYEGqlR1nG67/M14sp09+PTIRklobrn57IAxcdcO/ZFyNA==",
+      "license": "MPL-1.1"
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "license": "MIT"
     },
     "node_modules/markdown-extensions": {
       "version": "2.0.0",
@@ -13351,6 +13841,18 @@
       "license": "MIT",
       "dependencies": {
         "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
         "parse5": "^7.0.0"
       },
       "funding": {
@@ -17345,6 +17847,15 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -18222,6 +18733,40 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.6.3",
     "@docusaurus/preset-classic": "^3.6.3",
+    "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.1.0",
     "prism-react-renderer": "^2.3.0",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -20,6 +20,7 @@ const sidebars = {
       items: [
         'dashboard/overview',
         'dashboard/guild-mappings',
+        'dashboard/guilds',
         'dashboard/channels',
         'dashboard/filters',
         'dashboard/backfill',

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -105,6 +105,52 @@ table th {
   background: var(--ifm-color-emphasis-100);
 }
 
+/* Search bar */
+.navbar__search-input {
+  border-radius: 8px !important;
+  font-size: 0.85rem !important;
+  padding: 6px 36px 6px 32px !important;
+  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s !important;
+}
+
+.navbar__search-input:focus {
+  box-shadow: 0 0 0 2px rgba(114, 137, 218, 0.25) !important;
+}
+
+[data-theme='dark'] .navbar__search-input {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  border: 1px solid rgba(255, 255, 255, 0.1) !important;
+  color: #e0e0e0 !important;
+}
+
+[data-theme='dark'] .navbar__search-input::placeholder {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+[data-theme='dark'] .navbar__search-input:focus {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  border-color: var(--ifm-color-primary) !important;
+}
+
+/* Center search bar in navbar */
+.navbar {
+  position: relative;
+}
+
+.navbar .navbar__search {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+@media (max-width: 996px) {
+  .navbar .navbar__search {
+    position: static;
+    transform: none;
+  }
+}
+
 /* Responsive hero */
 @media (max-width: 768px) {
   .hero__title {


### PR DESCRIPTION
## Summary

- **Fast structure sync** — Removed custom rate limiter from all sync operations. Channels and categories create near-instantly using discord.py's native rate limit handling
- **On-demand webhooks** — New `ON_DEMAND_WEBHOOKS` toggle (default: true). Webhooks are created lazily on first message instead of during sync, eliminating the biggest cloning bottleneck
- **Cancel and restart** — New sitemaps cancel stale syncs instead of queuing behind them. Background tasks (roles, emojis, stickers) continue independently
- **Message buffering** — Messages for unmapped channels are queued and replayed after sync instead of being dropped
- **Auto-start** — New `AUTO_START` setting in Global Configuration. Validates tokens on boot and starts bots automatically
- **Log pruning** — New `MAX_LOG_SIZE_MB` setting (default: 10 MB). Memory-efficient pruning with atomic writes
- **Event logs overhaul** — Server-side pagination (50/page), server-side search, expandable rows with metadata (source/clone IDs, sync task ID), dynamic type filter, refresh button
- **Dashboard** — Per-log clear buttons with confirmation, fixed-size log modal, auto-start and log size in Global Config
- **Smarter limits** — Emoji/sticker sync stops immediately when guild limit is hit instead of spamming failed requests. Role operations include pacing to avoid rate limit walls
- **Slash commands** — Now work even when cloning is paused
- **Bug fixes** — Fixed shutdown traceback, duplicate channels from canceled syncs, wrong `original_guild_id` in on-demand webhook path, backfill `handle_message` crash, `sqlite3.Row` not dict error, thread on-demand webhook creation
- **Docs** — Updated structure sync, cloning options, advanced config, dashboard overview, system page. New Guilds page docs with export messages. Added local search to Docusaurus
