### PR TITLE
Graceful boost-level error handling with actionable warnings

### DIFF
--- a/code/server/permission_sync.py
+++ b/code/server/permission_sync.py
@@ -224,7 +224,7 @@ class ChannelPermissionSync:
             row = cat_map.get(int(cat["id"]))
             if not row:
                 self._log(
-                    "info",
+                    "debug",
                     "[perm-sync] skip category %s: no cat_map",
                     cat.get("id"),
                 )
@@ -243,8 +243,8 @@ class ChannelPermissionSync:
                 crow = chan_map.get(int(ch["id"]))
                 if not crow:
                     self._log(
-                        "info",
-                        "[perm-sync] skip channel %s: no chan_map",
+                        "debug",
+                        "[perm-sync] skip channel %s: no chan_map (excluded or not cloned)",
                         ch.get("id"),
                     )
                     continue
@@ -262,7 +262,7 @@ class ChannelPermissionSync:
             crow = chan_map.get(int(ch["id"]))
             if not crow:
                 self._log(
-                    "info",
+                    "debug",
                     "[perm-sync] skip channel %s: no chan_map (standalone)",
                     ch.get("id"),
                 )
@@ -287,7 +287,7 @@ class ChannelPermissionSync:
                 crow = chan_map.get(int(ch["id"]))
                 if not crow:
                     self._log(
-                        "info",
+                        "debug",
                         "[perm-sync] skip voice/stage channel %s: no chan_map",
                         ch.get("id"),
                     )
@@ -310,7 +310,7 @@ class ChannelPermissionSync:
             crow = chan_map.get(int(ch["id"]))
             if not crow:
                 self._log(
-                    "info",
+                    "debug",
                     "[perm-sync] skip voice/stage channel %s: no chan_map (standalone)",
                     ch.get("id"),
                 )
@@ -330,7 +330,7 @@ class ChannelPermissionSync:
             crow = chan_map.get(fm_id)
             if not crow:
                 self._log(
-                    "info",
+                    "debug",
                     "[perm-sync] skip forum %s: no chan_map",
                     fm.get("id"),
                 )
@@ -339,7 +339,7 @@ class ChannelPermissionSync:
             cch = guild.get_channel(int(crow.get("cloned_channel_id") or 0))
             if cch is None:
                 self._log(
-                    "info",
+                    "debug",
                     "[perm-sync] skip forum %s: cloned channel not found",
                     fm.get("id"),
                 )
@@ -348,7 +348,7 @@ class ChannelPermissionSync:
             ch_type_name = getattr(getattr(cch, "type", None), "name", "")
             if ch_type_name != "forum":
                 self._log(
-                    "info",
+                    "debug",
                     "[perm-sync] skip forum %s: cloned channel is not a forum (%r)",
                     fm.get("id"),
                     type(cch),

--- a/code/server/roles.py
+++ b/code/server/roles.py
@@ -332,12 +332,34 @@ class RoleManager:
             return cloned, 1, can_create, create_suppressed_logged
 
         except Exception as e:
-            self._log(
-                "warning",
-                "[⚠️] Failed recreating missing cloned role for %r: %s",
-                want_name,
-                e,
-            )
+            if "display_icon" in str(e):
+                kwargs.pop("display_icon", None)
+                try:
+                    cloned = await guild.create_role(**kwargs)
+                    await asyncio.sleep(self._ROLE_OP_DELAY)
+                    self.db.upsert_role_mapping(
+                        orig_id, want_name, cloned.id, cloned.name,
+                        original_guild_id=original_guild_id,
+                        cloned_guild_id=cloned_guild_id,
+                    )
+                    clone_by_id[cloned.id] = cloned
+                    self._log(
+                        "warning",
+                        "[⚠️] Created role '%s' without icon — clone server doesn't support role icons. "
+                        "Boost to Level 2+ or set CLONE_ROLE_ICONS to false.",
+                        want_name,
+                    )
+                    can_create = len(guild.roles) < self.MAX_ROLES
+                    return cloned, 1, can_create, create_suppressed_logged
+                except Exception as e2:
+                    self._log("warning", "[⚠️] Failed creating role %r: %s", want_name, e2)
+            else:
+                self._log(
+                    "warning",
+                    "[⚠️] Failed recreating missing cloned role for %r: %s",
+                    want_name,
+                    e,
+                )
             return None, 0, can_create, create_suppressed_logged
 
     async def _sync(
@@ -607,12 +629,34 @@ class RoleManager:
                     continue
 
                 except Exception as e:
-                    self._log(
-                        "warning",
-                        "[⚠️] Failed creating role %s: %s",
-                        want_name,
-                        e,
-                    )
+                    if "display_icon" in str(e):
+                        kwargs.pop("display_icon", None)
+                        try:
+                            new_role = await guild.create_role(**kwargs)
+                            await asyncio.sleep(self._ROLE_OP_DELAY)
+                            created += 1
+                            self.db.upsert_role_mapping(
+                                orig_id, want_name, new_role.id, new_role.name,
+                                original_guild_id=host_id, cloned_guild_id=clone_id,
+                            )
+                            clone_by_id[new_role.id] = new_role
+                            self._log(
+                                "warning",
+                                "[⚠️] Created role '%s' without icon — clone server doesn't support role icons. "
+                                "Boost to Level 2+ or set CLONE_ROLE_ICONS to false.",
+                                want_name,
+                            )
+                            can_create = len(guild.roles) < self.MAX_ROLES
+                            continue
+                        except Exception as e2:
+                            self._log("warning", "[⚠️] Failed creating role %s: %s", want_name, e2)
+                    else:
+                        self._log(
+                            "warning",
+                            "[⚠️] Failed creating role %s: %s",
+                            want_name,
+                            e,
+                        )
                     continue
 
             if (
@@ -743,12 +787,33 @@ class RoleManager:
                         )
 
                     except Exception as e:
-                        self._log(
-                            "warning",
-                            "[⚠️] Failed updating role %s: %s",
-                            getattr(cloned_role, "name", "?"),
-                            e,
-                        )
+                        msg = str(e)
+                        if "display_icon" in msg:
+                            kwargs.pop("display_icon", None)
+                            try:
+                                await cloned_role.edit(**kwargs)
+                                await asyncio.sleep(self._ROLE_OP_DELAY)
+                                updated += 1
+                                self._log(
+                                    "warning",
+                                    "[⚠️] Role '%s' updated without icon — clone server doesn't support role icons. "
+                                    "Boost to Level 2+ or set CLONE_ROLE_ICONS to false.",
+                                    getattr(cloned_role, "name", "?"),
+                                )
+                            except Exception as e2:
+                                self._log(
+                                    "warning",
+                                    "[⚠️] Failed updating role %s: %s",
+                                    getattr(cloned_role, "name", "?"),
+                                    e2,
+                                )
+                        else:
+                            self._log(
+                                "warning",
+                                "[⚠️] Failed updating role %s: %s",
+                                getattr(cloned_role, "name", "?"),
+                                e,
+                            )
         rearranged = 0
         if rearrange_roles:
             try:

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -2305,12 +2305,21 @@ class ServerReceiver:
                 guild_name=guild.name,
                 extra={"changed_fields": changed_fields},
             )
-        except Exception:
-            logger.warning(
-                "[⚠️] Failed to update guild metadata for clone guild %s",
-                guild.id,
-                exc_info=True,
-            )
+        except Exception as e:
+            msg = str(e)
+            if "cannot be larger than" in msg.lower() or "10240" in msg:
+                logger.warning(
+                    "[⚠️] Guild icon/banner too large for clone guild %s — "
+                    "the clone server's boost level doesn't support this file size. "
+                    "Boost the clone server or set CLONE_GUILD_ICON/CLONE_GUILD_BANNER to false.",
+                    guild.id,
+                )
+            else:
+                logger.warning(
+                    "[⚠️] Failed to update guild metadata for clone guild %s: %s",
+                    guild.id,
+                    e,
+                )
 
         return parts
 
@@ -3753,9 +3762,21 @@ class ServerReceiver:
                     )
 
             except Exception as e:
-                logger.warning(
-                    "[⚠️] Failed to update metadata for channel #%d: %s", ch.id, e
-                )
+                msg = str(e)
+                if "emoji you do not have access to" in msg.lower():
+                    logger.debug(
+                        "[⚠️] Channel #%d topic contains custom emojis not available in the clone server; skipping topic sync",
+                        ch.id,
+                    )
+                elif "96000" in msg or "less than or equal to" in msg.lower():
+                    logger.warning(
+                        "[⚠️] Bitrate too high for clone channel #%d — boost the clone server or disable voice/stage properties.",
+                        ch.id,
+                    )
+                else:
+                    logger.warning(
+                        "[⚠️] Failed to update metadata for channel #%d: %s", ch.id, e
+                    )
 
         for ch, desired_req in require_tag_ops:
             try:
@@ -4177,11 +4198,20 @@ class ServerReceiver:
                     ", ".join(f"{k}={v}" for k, v in voice_changes.items()),
                 )
             except Exception as e:
-                logger.warning(
-                    "[⚠️] Failed to set voice properties for new channel #%d: %s",
-                    ch.id,
-                    e,
-                )
+                msg = str(e)
+                if "96000" in msg or "less than or equal to" in msg.lower():
+                    logger.warning(
+                        "[⚠️] Voice bitrate too high for clone channel #%d — "
+                        "the clone server's boost level doesn't support this bitrate. "
+                        "Boost the clone server or set CLONE_VOICE_PROPERTIES to false.",
+                        ch.id,
+                    )
+                else:
+                    logger.warning(
+                        "[⚠️] Failed to set voice properties for channel #%d: %s",
+                        ch.id,
+                        e,
+                    )
 
         self.db.upsert_channel_mapping(
             int(original_id),
@@ -4361,11 +4391,20 @@ class ServerReceiver:
                     ", ".join(f"{k}={v}" for k, v in stage_changes.items()),
                 )
             except Exception as e:
-                logger.warning(
-                    "[⚠️] Failed to set stage properties for new channel #%d: %s",
-                    ch.id,
-                    e,
-                )
+                msg = str(e)
+                if "96000" in msg or "less than or equal to" in msg.lower():
+                    logger.warning(
+                        "[⚠️] Stage bitrate too high for clone channel #%d — "
+                        "the clone server's boost level doesn't support this bitrate. "
+                        "Boost the clone server or set CLONE_STAGE_PROPERTIES to false.",
+                        ch.id,
+                    )
+                else:
+                    logger.warning(
+                        "[⚠️] Failed to set stage properties for channel #%d: %s",
+                        ch.id,
+                        e,
+                    )
 
         self.db.upsert_channel_mapping(
             int(original_id),


### PR DESCRIPTION
## Summary

- **Guild metadata** — Icon/banner size errors now show a clean warning mentioning `CLONE_GUILD_ICON`/`CLONE_GUILD_BANNER` instead of a full traceback
- **Voice/stage channels** — Bitrate errors warn about boost level and mention `CLONE_VOICE_PROPERTIES`/`CLONE_STAGE_PROPERTIES`
- **Role icons** — When clone server lacks Boost Level 2+, role create/update retries without the icon and warns to set `CLONE_ROLE_ICONS` to false
- **Channel topics** — Custom emoji errors quieted to DEBUG (harmless, no action needed)