### PR TITLE
Better Client Proxy Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Copycord is the ultimate Discord server mirroring tool. Effortlessly clone multi
 ```yaml
 services:
   admin:
-    image: ghcr.io/copycord/copycord:v3.20.2
+    image: ghcr.io/copycord/copycord:v3.21.0
     container_name: copycord-admin
     environment:
       - ROLE=admin
@@ -112,7 +112,7 @@ services:
     restart: unless-stopped
 
   server:
-    image: ghcr.io/copycord/copycord:v3.20.2
+    image: ghcr.io/copycord/copycord:v3.21.0
     container_name: copycord-server
     environment:
       - ROLE=server
@@ -123,7 +123,7 @@ services:
     restart: unless-stopped
 
   client:
-    image: ghcr.io/copycord/copycord:v3.20.2
+    image: ghcr.io/copycord/copycord:v3.21.0
     container_name: copycord-client
     environment:
       - ROLE=client

--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -3963,6 +3963,49 @@ async def api_server_proxies_rotation_interval(request: Request):
         return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
 
 
+_PROXY_SETTINGS_KEYS = {
+    "PROXY_SUSPEND_DURATION": 300,
+    "PROXY_TEST_BATCH_SIZE": 50,
+    "PROXY_SLOW_THRESHOLD": 3,
+}
+
+
+@app.get("/api/server/proxies/settings", response_class=JSONResponse)
+async def api_proxy_settings_get():
+    """Return proxy settings."""
+    try:
+        settings = {}
+        for key, default in _PROXY_SETTINGS_KEYS.items():
+            raw = (db.get_config(key, "") or "").strip()
+            try:
+                settings[key] = int(raw) if raw else default
+            except (ValueError, TypeError):
+                settings[key] = default
+        return JSONResponse({"ok": True, "settings": settings})
+    except Exception as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+
+@app.put("/api/server/proxies/settings", response_class=JSONResponse)
+async def api_proxy_settings_put(request: Request):
+    """Save proxy settings."""
+    try:
+        payload = await request.json()
+    except Exception:
+        raise HTTPException(400, detail="Invalid JSON")
+    settings = payload.get("settings", {})
+    if not isinstance(settings, dict):
+        raise HTTPException(400, detail="settings must be an object")
+    try:
+        for key, default in _PROXY_SETTINGS_KEYS.items():
+            if key in settings:
+                val = max(1, int(settings[key]))
+                db.set_config(key, str(val))
+        return JSONResponse({"ok": True})
+    except Exception as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+
 _proxy_test_task: Optional[asyncio.Task] = None
 
 
@@ -4012,7 +4055,8 @@ async def api_server_proxies_test(request: Request):
         ProxyConnector = None
 
     test_url = "https://discord.com/api/v9/gateway"
-    batch_size = int(os.getenv("PROXY_TEST_BATCH_SIZE", "50"))
+    _batch_raw = (db.get_config("PROXY_TEST_BATCH_SIZE", "") or "").strip()
+    batch_size = int(_batch_raw) if _batch_raw else 50
     _timeout = aiohttp.ClientTimeout(total=5)
 
     async def _test_one(raw_proxy: str):

--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -3885,24 +3885,34 @@ async def api_scraper_proxies_put(request: Request):
 
 @app.get("/api/server/proxies", response_class=JSONResponse)
 async def api_server_proxies_get():
-    """Return server proxy list and enabled state."""
+    """Return client proxy list, enabled state, and rotation interval."""
     try:
         if _PROXY_FILE.exists():
             text = _PROXY_FILE.read_text(encoding="utf-8").strip()
             lines = [l.strip() for l in text.splitlines() if l.strip()]
         else:
             lines = []
-        enabled = (db.get_config("ENABLE_SERVER_PROXIES", "") or "").strip().lower() in (
+        enabled = (db.get_config("ENABLE_CLIENT_PROXIES", "") or "").strip().lower() in (
             "1", "true", "yes",
         )
-        return JSONResponse({"ok": True, "proxies": lines, "enabled": enabled})
+        interval_raw = (db.get_config("PROXY_ROTATION_INTERVAL", "") or "").strip()
+        try:
+            rotation_interval = int(interval_raw) if interval_raw else 0
+        except (ValueError, TypeError):
+            rotation_interval = 0
+        return JSONResponse({
+            "ok": True,
+            "proxies": lines,
+            "enabled": enabled,
+            "rotation_interval": rotation_interval,
+        })
     except Exception as e:
         return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
 
 
 @app.put("/api/server/proxies", response_class=JSONResponse)
 async def api_server_proxies_put(request: Request):
-    """Save server proxy list (shared file with scraper)."""
+    """Save client proxy list (shared file with scraper)."""
     try:
         payload = await request.json()
     except Exception:
@@ -3922,15 +3932,33 @@ async def api_server_proxies_put(request: Request):
 
 @app.put("/api/server/proxies/toggle", response_class=JSONResponse)
 async def api_server_proxies_toggle(request: Request):
-    """Enable or disable server proxy rotation."""
+    """Enable or disable client proxy rotation."""
     try:
         payload = await request.json()
     except Exception:
         raise HTTPException(400, detail="Invalid JSON")
     enabled = bool(payload.get("enabled", False))
     try:
-        db.set_config("ENABLE_SERVER_PROXIES", "true" if enabled else "false")
+        db.set_config("ENABLE_CLIENT_PROXIES", "true" if enabled else "false")
         return JSONResponse({"ok": True, "enabled": enabled})
+    except Exception as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+
+@app.put("/api/server/proxies/rotation-interval", response_class=JSONResponse)
+async def api_server_proxies_rotation_interval(request: Request):
+    """Set the proxy rotation interval in seconds (0 = per-request)."""
+    try:
+        payload = await request.json()
+    except Exception:
+        raise HTTPException(400, detail="Invalid JSON")
+    try:
+        interval = max(0, int(payload.get("interval", 0)))
+    except (ValueError, TypeError):
+        raise HTTPException(400, detail="interval must be an integer")
+    try:
+        db.set_config("PROXY_ROTATION_INTERVAL", str(interval))
+        return JSONResponse({"ok": True, "rotation_interval": interval})
     except Exception as e:
         return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
 

--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -3963,6 +3963,164 @@ async def api_server_proxies_rotation_interval(request: Request):
         return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
 
 
+_proxy_test_task: Optional[asyncio.Task] = None
+
+
+@app.post("/api/server/proxies/test", response_class=JSONResponse)
+async def api_server_proxies_test(request: Request):
+    """Start a background proxy test task. Results streamed via hub broadcast."""
+    global _proxy_test_task
+    import re as _re
+
+    if _proxy_test_task and not _proxy_test_task.done():
+        return JSONResponse({"ok": False, "error": "Test already running"}, status_code=409)
+
+    try:
+        payload = await request.json()
+    except Exception:
+        raise HTTPException(400, detail="Invalid JSON")
+    proxies = payload.get("proxies", [])
+    if not isinstance(proxies, list) or not proxies:
+        raise HTTPException(400, detail="proxies must be a non-empty list")
+
+    _HP_UP = _re.compile(r"^(?P<host>[^:]+):(?P<port>\d+):(?P<user>[^:]+):(?P<pass>.+)$")
+    _UP_HP = _re.compile(r"^(?P<user>[^:@]+):(?P<pass>[^@]+)@(?P<host>[^:]+):(?P<port>\d+)$")
+
+    def _normalise(raw: str):
+        raw = raw.strip()
+        if not raw:
+            return None
+        scheme = "http"
+        if "://" in raw:
+            scheme, _, raw = raw.partition("://")
+        m = _HP_UP.match(raw)
+        if m:
+            return f"{scheme}://{m.group('user')}:{m.group('pass')}@{m.group('host')}:{m.group('port')}"
+        m = _UP_HP.match(raw)
+        if m:
+            return f"{scheme}://{raw}"
+        if ":" in raw:
+            return f"{scheme}://{raw}"
+        return None
+
+    def _is_socks(url: str) -> bool:
+        return url.lower().startswith(("socks4://", "socks5://", "socks4a://", "socks5h://"))
+
+    try:
+        from aiohttp_socks import ProxyConnector
+    except ImportError:
+        ProxyConnector = None
+
+    test_url = "https://discord.com/api/v9/gateway"
+    batch_size = int(os.getenv("PROXY_TEST_BATCH_SIZE", "50"))
+    _timeout = aiohttp.ClientTimeout(total=5)
+
+    async def _test_one(raw_proxy: str):
+        url = _normalise(raw_proxy)
+        if not url:
+            return {"proxy": raw_proxy, "ok": False, "error": "Invalid format", "ms": None}
+        import time as _time
+        t0 = _time.monotonic()
+        try:
+            if _is_socks(url):
+                if ProxyConnector is None:
+                    return {"proxy": raw_proxy, "ok": False, "error": "aiohttp_socks not installed", "ms": None}
+                connector = ProxyConnector.from_url(url)
+                async with aiohttp.ClientSession(connector=connector) as sess:
+                    async with sess.get(test_url, timeout=_timeout) as resp:
+                        ms = round((_time.monotonic() - t0) * 1000)
+                        return {"proxy": raw_proxy, "ok": resp.status == 200, "status": resp.status, "ms": ms}
+            else:
+                async with aiohttp.ClientSession() as sess:
+                    async with sess.get(test_url, proxy=url, timeout=_timeout) as resp:
+                        ms = round((_time.monotonic() - t0) * 1000)
+                        return {"proxy": raw_proxy, "ok": resp.status == 200, "status": resp.status, "ms": ms}
+        except Exception as e:
+            ms = round((_time.monotonic() - t0) * 1000)
+            return {"proxy": raw_proxy, "ok": False, "error": type(e).__name__, "ms": ms}
+
+    async def _run_test(proxy_list: list):
+        import time as _time
+        total = len(proxy_list)
+        all_results = []
+        completed = 0
+        t_start = _time.monotonic()
+
+        LOGGER.info("[🔀] Proxy test started: %d proxies (batch=%d, timeout=%ds)", total, batch_size, 5)
+
+        await hub.broadcast({
+            "kind": "proxy_test", "role": "admin",
+            "payload": {"type": "started", "total": total},
+        })
+
+        try:
+            for i in range(0, total, batch_size):
+                batch = proxy_list[i : i + batch_size]
+                batch_num = (i // batch_size) + 1
+                total_batches = (total + batch_size - 1) // batch_size
+                LOGGER.info("[🔀] Proxy test batch %d/%d (%d proxies)", batch_num, total_batches, len(batch))
+
+                batch_results = await asyncio.gather(*[_test_one(p) for p in batch])
+                all_results.extend(batch_results)
+                completed += len(batch_results)
+
+                batch_passed = sum(1 for r in batch_results if r.get("ok"))
+                batch_failed = len(batch_results) - batch_passed
+                LOGGER.info("[🔀] Proxy test batch %d/%d done: %d passed, %d failed", batch_num, total_batches, batch_passed, batch_failed)
+
+                await hub.broadcast({
+                    "kind": "proxy_test", "role": "admin",
+                    "payload": {
+                        "type": "progress",
+                        "current": completed,
+                        "total": total,
+                        "results": list(batch_results),
+                    },
+                })
+
+            elapsed = round(_time.monotonic() - t_start, 1)
+            total_passed = sum(1 for r in all_results if r.get("ok"))
+            total_failed = total - total_passed
+            LOGGER.info("[🔀] Proxy test complete: %d/%d passed, %d failed (%.1fs)", total_passed, total, total_failed, elapsed)
+
+            await hub.broadcast({
+                "kind": "proxy_test", "role": "admin",
+                "payload": {
+                    "type": "complete",
+                    "total": total,
+                    "results": all_results,
+                },
+            })
+        except asyncio.CancelledError:
+            elapsed = round(_time.monotonic() - t_start, 1)
+            LOGGER.info("[🔀] Proxy test stopped after %d/%d proxies (%.1fs)", completed, total, elapsed)
+
+    _proxy_test_task = asyncio.create_task(_run_test(proxies))
+    return JSONResponse({"ok": True, "total": len(proxies)})
+
+
+@app.get("/api/server/proxies/test/status", response_class=JSONResponse)
+async def api_server_proxies_test_status():
+    """Check if a proxy test is currently running."""
+    running = _proxy_test_task is not None and not _proxy_test_task.done()
+    return JSONResponse({"ok": True, "running": running})
+
+
+@app.post("/api/server/proxies/test/stop", response_class=JSONResponse)
+async def api_server_proxies_test_stop():
+    """Stop a running proxy test."""
+    global _proxy_test_task
+    if _proxy_test_task and not _proxy_test_task.done():
+        _proxy_test_task.cancel()
+        LOGGER.info("[🔀] Proxy test stopped by user")
+        await hub.broadcast({
+            "kind": "proxy_test", "role": "admin",
+            "payload": {"type": "stopped"},
+        })
+        return JSONResponse({"ok": True})
+    return JSONResponse({"ok": False, "error": "No test running"})
+
+
 @app.post("/api/scraper/start", response_class=JSONResponse)
 async def api_scraper_start(request: Request):
     """Start standalone scraper with multiple tokens (single guild, immediate start)."""

--- a/code/admin/frontend/src/js/app.js
+++ b/code/admin/frontend/src/js/app.js
@@ -4762,41 +4762,195 @@
 
     refreshGuildMappings();
 
-    // ─── Server Proxy Rotation ─────────────────────────────────────────────
+    // ─── Client Proxy Rotation ──────────────────────────────────────────────
     const srvProxyCard    = document.getElementById("srv-proxy-card");
     const srvProxyToggle  = document.getElementById("srv-proxy-toggle");
-    const srvProxyTa      = document.getElementById("srv-proxy-textarea");
-    const srvProxyCount   = document.getElementById("srv-proxy-count");
+    const srvProxyChips   = document.getElementById("srv-proxy-chips");
+    const srvProxyInput   = document.getElementById("srv-proxy-chips-input");
     const srvProxyStatus  = document.getElementById("srv-proxy-status");
-    const srvProxySave    = document.getElementById("srv-proxy-save");
     const srvProxyClear   = document.getElementById("srv-proxy-clear");
-    const srvPrependHttp  = document.getElementById("srv-proxy-prepend-http");
-    const srvPrependSocks = document.getElementById("srv-proxy-prepend-socks5");
 
-    function srvProxyLines() {
-      if (!srvProxyTa) return [];
-      return srvProxyTa.value.split("\n").map(l => l.trim()).filter(Boolean);
+    const srvRotationToggle   = document.getElementById("srv-proxy-rotation-toggle");
+    const srvRotationControls = document.getElementById("srv-proxy-rotation-controls");
+    const srvIntervalInput    = document.getElementById("srv-proxy-interval");
+    const srvIntervalUnit     = document.getElementById("srv-proxy-interval-unit");
+
+    // ── Proxy chip helpers ──
+
+    function getProxyChipValues() {
+      if (!srvProxyChips) return [];
+      return Array.from(srvProxyChips.querySelectorAll(".srv-proxy-chip-item"))
+        .map(el => el.dataset.proxy)
+        .filter(Boolean);
     }
 
-    function updateSrvProxyCount() {
-      if (!srvProxyCount) return;
-      const n = srvProxyLines().length;
-      srvProxyCount.textContent = n > 0 ? `${n} proxy${n !== 1 ? "ies" : ""}` : "";
+    function createProxyChip(proxy) {
+      const el = document.createElement("span");
+      el.className = "srv-proxy-chip-item";
+      el.dataset.proxy = proxy;
+      el.innerHTML = `<span class="srv-proxy-chip-text">${escapeHtml(proxy)}</span><span class="srv-proxy-chip-x">×</span>`;
+      el.querySelector(".srv-proxy-chip-x").addEventListener("click", () => {
+        el.remove();
+        refreshStatusChip();
+        scheduleProxySave();
+      });
+      return el;
     }
 
-    function updateSrvProxyStatus(enabled, count) {
-      if (!srvProxyStatus) return;
-      if (enabled && count > 0) {
-        srvProxyStatus.textContent = `Enabled · ${count} proxy${count !== 1 ? "ies" : ""}`;
-        srvProxyStatus.className = "srv-proxy-status is-on";
-      } else if (enabled) {
-        srvProxyStatus.textContent = "Enabled · no proxies loaded";
-        srvProxyStatus.className = "srv-proxy-status is-warn";
-      } else {
-        srvProxyStatus.textContent = "Disabled";
-        srvProxyStatus.className = "srv-proxy-status";
+    function escapeHtml(s) {
+      const d = document.createElement("div");
+      d.textContent = s;
+      return d.innerHTML;
+    }
+
+    function addProxies(text) {
+      if (!srvProxyChips || !text) return;
+      const existing = new Set(getProxyChipValues());
+      const lines = text.split(/[\n\r,]+/).map(l => l.trim()).filter(Boolean);
+      let added = false;
+      for (const line of lines) {
+        if (!existing.has(line)) {
+          existing.add(line);
+          srvProxyChips.insertBefore(createProxyChip(line), srvProxyInput);
+          added = true;
+        }
+      }
+      if (added) {
+        refreshStatusChip();
+        scheduleProxySave();
       }
     }
+
+    function setProxyChips(proxies) {
+      if (!srvProxyChips) return;
+      srvProxyChips.querySelectorAll(".srv-proxy-chip-item").forEach(el => el.remove());
+      for (const p of proxies) {
+        srvProxyChips.insertBefore(createProxyChip(p), srvProxyInput);
+      }
+      refreshStatusChip();
+    }
+
+    function pluralProxy(n) {
+      return n === 1 ? "1 proxy" : `${n} proxies`;
+    }
+
+    function refreshStatusChip() {
+      updateSrvProxyChip(srvProxyToggle?.checked, getProxyChipValues().length);
+    }
+
+    function updateSrvProxyChip(enabled, count) {
+      if (!srvProxyStatus) return;
+      if (enabled && count > 0) {
+        srvProxyStatus.textContent = `Enabled · ${pluralProxy(count)}`;
+        srvProxyStatus.className = "srv-proxy-chip is-on";
+      } else if (enabled) {
+        srvProxyStatus.textContent = "Enabled · no proxies";
+        srvProxyStatus.className = "srv-proxy-chip is-warn";
+      } else {
+        srvProxyStatus.textContent = "Disabled";
+        srvProxyStatus.className = "srv-proxy-chip";
+      }
+    }
+
+    function updateRotationControls(intervalSec) {
+      if (!srvRotationControls || !srvRotationToggle) return;
+      const on = intervalSec > 0;
+      srvRotationToggle.checked = on;
+      srvRotationControls.classList.toggle("is-hidden", !on);
+      if (on && srvIntervalInput && srvIntervalUnit) {
+        if (intervalSec >= 3600 && intervalSec % 3600 === 0) {
+          srvIntervalInput.value = intervalSec / 3600;
+          srvIntervalUnit.value = "3600";
+        } else {
+          srvIntervalInput.value = Math.max(1, Math.round(intervalSec / 60));
+          srvIntervalUnit.value = "60";
+        }
+      }
+    }
+
+    function getRotationIntervalSec() {
+      if (!srvRotationToggle || !srvRotationToggle.checked) return 0;
+      if (!srvIntervalInput || !srvIntervalUnit) return 0;
+      const val = Math.max(1, parseInt(srvIntervalInput.value, 10) || 1);
+      const multiplier = parseInt(srvIntervalUnit.value, 10) || 60;
+      return val * multiplier;
+    }
+
+    // ── Input handling ──
+
+    if (srvProxyInput) {
+      srvProxyInput.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          const val = srvProxyInput.value.trim();
+          if (val) {
+            addProxies(val);
+            srvProxyInput.value = "";
+          }
+        }
+        // Backspace on empty input removes last chip
+        if (e.key === "Backspace" && !srvProxyInput.value) {
+          const chips = srvProxyChips.querySelectorAll(".srv-proxy-chip-item");
+          if (chips.length) {
+            chips[chips.length - 1].remove();
+            refreshStatusChip();
+            scheduleProxySave();
+          }
+        }
+      });
+      srvProxyInput.addEventListener("paste", (e) => {
+        e.preventDefault();
+        const text = (e.clipboardData || window.clipboardData).getData("text");
+        if (text) {
+          addProxies(text);
+          srvProxyInput.value = "";
+        }
+      });
+    }
+
+    // Click on container focuses input
+    if (srvProxyChips && srvProxyInput) {
+      srvProxyChips.addEventListener("click", (e) => {
+        if (e.target === srvProxyChips) srvProxyInput.focus();
+      });
+    }
+
+    // ── Auto-save (debounced) ──
+
+    let _proxySaveTimer = null;
+    function scheduleProxySave() {
+      clearTimeout(_proxySaveTimer);
+      _proxySaveTimer = setTimeout(saveProxySettings, 400);
+    }
+
+    async function saveProxySettings() {
+      const lines = getProxyChipValues();
+      const intervalSec = getRotationIntervalSec();
+      try {
+        const [rProxies, rInterval] = await Promise.all([
+          fetch("/api/server/proxies", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ proxies: lines }),
+          }),
+          fetch("/api/server/proxies/rotation-interval", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ interval: intervalSec }),
+          }),
+        ]);
+        const jProxies = await rProxies.json();
+        const jInterval = await rInterval.json();
+        if (!jProxies.ok) showToast(jProxies.error || "Failed to save proxies", { type: "error" });
+        if (!jInterval.ok) showToast(jInterval.error || "Failed to save rotation", { type: "error" });
+        updateSrvProxyChip(srvProxyToggle?.checked, lines.length);
+      } catch (e) {
+        console.error(e);
+        showToast("Failed to save proxy settings", { type: "error" });
+      }
+    }
+
+    // ── API calls ──
 
     async function loadSrvProxies() {
       if (!srvProxyCard) return;
@@ -4804,35 +4958,13 @@
         const r = await fetch("/api/server/proxies");
         const j = await r.json();
         if (j.ok) {
-          if (srvProxyTa) srvProxyTa.value = (j.proxies || []).join("\n");
+          setProxyChips(j.proxies || []);
           if (srvProxyToggle) srvProxyToggle.checked = !!j.enabled;
-          updateSrvProxyCount();
-          updateSrvProxyStatus(!!j.enabled, (j.proxies || []).length);
+          updateSrvProxyChip(!!j.enabled, (j.proxies || []).length);
+          updateRotationControls(j.rotation_interval || 0);
         }
       } catch (e) {
-        console.error("Failed to load server proxies:", e);
-      }
-    }
-
-    async function saveSrvProxies() {
-      const lines = srvProxyLines();
-      try {
-        const r = await fetch("/api/server/proxies", {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ proxies: lines }),
-        });
-        const j = await r.json();
-        if (j.ok) {
-          showToast(`Saved ${lines.length} server prox${lines.length !== 1 ? "ies" : "y"}`, { type: "success" });
-          updateSrvProxyCount();
-          updateSrvProxyStatus(srvProxyToggle?.checked, lines.length);
-        } else {
-          showToast(j.error || "Failed to save proxies", { type: "error" });
-        }
-      } catch (e) {
-        console.error(e);
-        showToast("Failed to save proxies", { type: "error" });
+        console.error("Failed to load client proxies:", e);
       }
     }
 
@@ -4845,39 +4977,62 @@
         });
         const j = await r.json();
         if (j.ok) {
-          const count = srvProxyLines().length;
+          const count = getProxyChipValues().length;
           showToast(
             enabled
-              ? `Proxy rotation enabled (${count} prox${count !== 1 ? "ies" : "y"})`
-              : "Proxy rotation disabled",
+              ? `Client proxies enabled (${pluralProxy(count)})`
+              : "Client proxies disabled",
             { type: "success" }
           );
-          updateSrvProxyStatus(enabled, count);
+          updateSrvProxyChip(enabled, count);
         } else {
           showToast(j.error || "Failed to toggle", { type: "error" });
         }
       } catch (e) {
         console.error(e);
-        showToast("Failed to toggle proxy rotation", { type: "error" });
+        showToast("Failed to toggle client proxies", { type: "error" });
       }
     }
 
-    function srvPrependScheme(scheme) {
-      if (!srvProxyTa) return;
-      srvProxyTa.value = srvProxyTa.value.split("\n").map(line => {
-        const l = line.trim();
-        if (!l || l.includes("://")) return line;
-        return `${scheme}${l}`;
-      }).join("\n");
-      updateSrvProxyCount();
+    function toggleRotation(enabled) {
+      if (srvRotationControls) {
+        srvRotationControls.classList.toggle("is-hidden", !enabled);
+      }
+      scheduleProxySave();
     }
 
-    if (srvProxySave)    srvProxySave.addEventListener("click", () => saveSrvProxies());
-    if (srvProxyClear)   srvProxyClear.addEventListener("click", async () => { if (srvProxyTa) srvProxyTa.value = ""; await saveSrvProxies(); });
-    if (srvProxyTa)      srvProxyTa.addEventListener("input", updateSrvProxyCount);
-    if (srvProxyToggle)  srvProxyToggle.addEventListener("change", () => toggleSrvProxies(srvProxyToggle.checked));
-    if (srvPrependHttp)  srvPrependHttp.addEventListener("click", () => srvPrependScheme("http://"));
-    if (srvPrependSocks) srvPrependSocks.addEventListener("click", () => srvPrependScheme("socks5://"));
+    if (srvProxyClear)      srvProxyClear.addEventListener("click", () => {
+      if (!getProxyChipValues().length) return;
+      openConfirm({
+        title: "Clear all proxies?",
+        body: "This will remove all proxies from the list.",
+        confirmText: "Clear",
+        confirmClass: "btn-ghost-red",
+        showCancel: true,
+        onConfirm: () => { setProxyChips([]); saveProxySettings(); },
+      });
+    });
+    if (srvProxyToggle)     srvProxyToggle.addEventListener("change", () => toggleSrvProxies(srvProxyToggle.checked));
+    if (srvRotationToggle)  srvRotationToggle.addEventListener("change", () => toggleRotation(srvRotationToggle.checked));
+    if (srvIntervalInput) {
+      srvIntervalInput.addEventListener("input", () => {
+        const v = parseInt(srvIntervalInput.value, 10);
+        if (v < 1 && srvIntervalInput.value !== "") srvIntervalInput.value = 1;
+      });
+      srvIntervalInput.addEventListener("change", () => {
+        if (!srvIntervalInput.value || parseInt(srvIntervalInput.value, 10) < 1) srvIntervalInput.value = 1;
+        scheduleProxySave();
+      });
+    }
+    if (srvIntervalUnit)    srvIntervalUnit.addEventListener("change", () => scheduleProxySave());
+
+    // Persist open/closed state
+    if (srvProxyCard) {
+      if (localStorage.getItem("cpc.proxy-card-open") === "1") srvProxyCard.open = true;
+      srvProxyCard.addEventListener("toggle", () => {
+        localStorage.setItem("cpc.proxy-card-open", srvProxyCard.open ? "1" : "0");
+      });
+    }
 
     loadSrvProxies();
   });

--- a/code/admin/frontend/src/js/app.js
+++ b/code/admin/frontend/src/js/app.js
@@ -5009,7 +5009,7 @@
       scheduleProxySave();
     }
 
-    const SLOW_THRESHOLD_MS = 3000;
+    let SLOW_THRESHOLD_MS = 3000;
     const proxyProgress     = document.getElementById("srv-proxy-progress");
     const proxyProgressFill = document.getElementById("srv-proxy-progress-fill");
     const proxyProgressText = document.getElementById("srv-proxy-progress-text");
@@ -5302,8 +5302,113 @@
       });
     }
 
+    // ─── Proxy Settings Modal ──────────────────────────────────────────────
+    const psModal     = document.getElementById("proxy-settings-modal");
+    const psClose     = document.getElementById("proxy-settings-close");
+    const psBtn       = document.getElementById("srv-proxy-settings-btn");
+    const psFields    = {
+      PROXY_SUSPEND_DURATION: document.getElementById("ps-suspend-duration"),
+      PROXY_TEST_BATCH_SIZE:  document.getElementById("ps-test-batch"),
+      PROXY_SLOW_THRESHOLD:   document.getElementById("ps-slow-threshold"),
+    };
+
+    let _psLoaded = false;
+
+    function openProxySettings() {
+      if (!psModal) return;
+      psModal.classList.add("show");
+      psModal.setAttribute("aria-hidden", "false");
+      document.body.classList.add("body-lock-scroll");
+      if (!_psLoaded) loadProxySettings();
+    }
+
+    function closeProxySettings() {
+      if (!psModal) return;
+      psModal.classList.remove("show");
+      psModal.setAttribute("aria-hidden", "true");
+      const anyOther = document.querySelector(
+        "#confirm-modal.show, #log-modal.show, #mapping-modal.show, #filters-modal.show"
+      );
+      if (!anyOther) document.body.classList.remove("body-lock-scroll");
+    }
+
+    async function loadProxySettings() {
+      try {
+        const r = await fetch("/api/server/proxies/settings");
+        const j = await r.json();
+        if (j.ok && j.settings) {
+          for (const [key, el] of Object.entries(psFields)) {
+            if (el && j.settings[key] !== undefined) el.value = j.settings[key];
+          }
+          // Sync slow threshold to test UI
+          if (j.settings.PROXY_SLOW_THRESHOLD) {
+            SLOW_THRESHOLD_MS = j.settings.PROXY_SLOW_THRESHOLD * 1000;
+          }
+          _psLoaded = true;
+        }
+      } catch (e) {
+        console.error("Failed to load proxy settings:", e);
+      }
+    }
+
+    let _psSaveTimer = null;
+    function scheduleProxySettingsSave() {
+      clearTimeout(_psSaveTimer);
+      _psSaveTimer = setTimeout(saveProxySettings_modal, 600);
+    }
+
+    async function saveProxySettings_modal() {
+      const settings = {};
+      for (const [key, el] of Object.entries(psFields)) {
+        if (el) settings[key] = parseInt(el.value, 10) || 1;
+      }
+      // Sync slow threshold immediately
+      if (settings.PROXY_SLOW_THRESHOLD) {
+        SLOW_THRESHOLD_MS = settings.PROXY_SLOW_THRESHOLD * 1000;
+      }
+      try {
+        const r = await fetch("/api/server/proxies/settings", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ settings }),
+        });
+        const j = await r.json();
+        if (!j.ok) showToast(j.error || "Failed to save settings", { type: "error" });
+      } catch (e) {
+        console.error(e);
+        showToast("Failed to save proxy settings", { type: "error" });
+      }
+    }
+
+    if (psBtn) psBtn.addEventListener("click", openProxySettings);
+    if (psClose) psClose.addEventListener("click", closeProxySettings);
+    if (psModal) {
+      psModal.querySelector(".modal-backdrop")?.addEventListener("click", closeProxySettings);
+    }
+    for (const el of Object.values(psFields)) {
+      if (el) el.addEventListener("change", scheduleProxySettingsSave);
+    }
+
+    const PS_DEFAULTS = {
+      PROXY_SUSPEND_DURATION: 300,
+      PROXY_TEST_BATCH_SIZE: 50,
+      PROXY_SLOW_THRESHOLD: 3,
+    };
+    const psResetBtn = document.getElementById("ps-reset-defaults");
+    if (psResetBtn) {
+      psResetBtn.addEventListener("click", () => {
+        for (const [key, el] of Object.entries(psFields)) {
+          if (el && PS_DEFAULTS[key] !== undefined) el.value = PS_DEFAULTS[key];
+        }
+        SLOW_THRESHOLD_MS = PS_DEFAULTS.PROXY_SLOW_THRESHOLD * 1000;
+        saveProxySettings_modal();
+        showToast("Proxy settings reset to defaults", { type: "success" });
+      });
+    }
+
     loadSrvProxies();
     checkProxyTestStatus();
+    loadProxySettings();
   });
 
   ["server", "client"].forEach((role) => {

--- a/code/admin/frontend/src/js/app.js
+++ b/code/admin/frontend/src/js/app.js
@@ -3588,7 +3588,7 @@
     lastFocusConfirm = document.activeElement;
 
     cTitle.textContent = title || "Confirm";
-    cBody.textContent = body || "Are you sure?";
+    cBody.innerHTML = body || "Are you sure?";
     cBtnOk.textContent = confirmText || "OK";
 
     cBtnOk.classList.remove(
@@ -4525,6 +4525,10 @@
         location.host +
         "/ws/out";
       const ws = new WebSocket(url);
+      let wsReady = false;
+
+      // Ignore replayed history — only process live events after a short delay
+      setTimeout(() => { wsReady = true; }, 1500);
 
       ws.onmessage = (ev) => {
         try {
@@ -4532,6 +4536,9 @@
           if (msg.kind === "agent" && msg.type === "status") {
             const prefix = msg.role === "server" ? "server" : "client";
             renderStatusRow(prefix, msg.data || {});
+          }
+          if (msg.kind === "proxy_test" && msg.payload && wsReady) {
+            handleProxyTestEvent(msg.payload);
           }
           if (msg.type === "info")
             showToast(msg.data?.msg || "Info", { type: "success" });
@@ -4769,6 +4776,7 @@
     const srvProxyInput   = document.getElementById("srv-proxy-chips-input");
     const srvProxyStatus  = document.getElementById("srv-proxy-status");
     const srvProxyClear   = document.getElementById("srv-proxy-clear");
+    const srvProxyTest    = document.getElementById("srv-proxy-test");
 
     const srvRotationToggle   = document.getElementById("srv-proxy-rotation-toggle");
     const srvRotationControls = document.getElementById("srv-proxy-rotation-controls");
@@ -5001,6 +5009,266 @@
       scheduleProxySave();
     }
 
+    const SLOW_THRESHOLD_MS = 3000;
+    const proxyProgress     = document.getElementById("srv-proxy-progress");
+    const proxyProgressFill = document.getElementById("srv-proxy-progress-fill");
+    const proxyProgressText = document.getElementById("srv-proxy-progress-text");
+
+    function maskProxy(p) {
+      return p.includes("@") ? p.replace(/\/\/[^@]+@/, "//***@") : p;
+    }
+
+    function buildProxyResultRow(r, category) {
+      const masked = escapeHtml(maskProxy(r.proxy));
+      const color = category === "failed" ? "#ff6b6b" : category === "slow" ? "#ff9800" : "#4caf50";
+      const icon = category === "failed" ? "✗" : category === "slow" ? "⚠" : "✓";
+      const detail = r.ok ? `${r.ms}ms` : (r.error || "failed");
+      return `<div style="display:flex;align-items:center;gap:8px;padding:4px 0;font-size:12px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">`
+        + `<span style="color:${color};flex-shrink:0">${icon}</span>`
+        + `<span style="color:var(--text);min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1">${masked}</span>`
+        + `<span style="color:${color};flex-shrink:0;font-size:11px">${escapeHtml(detail)}</span>`
+        + `</div>`;
+    }
+
+    function showProxyProgress(current, total) {
+      if (!proxyProgress) return;
+      proxyProgress.style.display = "flex";
+      const pct = total > 0 ? Math.round((current / total) * 100) : 0;
+      if (proxyProgressFill) proxyProgressFill.style.width = pct + "%";
+      if (proxyProgressText) proxyProgressText.textContent = `${current} / ${total}`;
+    }
+
+    function hideProxyProgress() {
+      if (proxyProgress) proxyProgress.style.display = "none";
+      if (proxyProgressFill) proxyProgressFill.style.width = "0%";
+    }
+
+    function applyBatchResultsToChips(results) {
+      const chipEls = srvProxyChips.querySelectorAll(".srv-proxy-chip-item");
+      for (const result of results) {
+        const chip = Array.from(chipEls).find(el => el.dataset.proxy === result.proxy);
+        if (!chip) continue;
+        chip.classList.remove("test-loading");
+        const msEl = chip.querySelector(".srv-proxy-chip-ms");
+        if (!result.ok) {
+          chip.classList.add("test-fail");
+          if (msEl) msEl.textContent = result.error || "failed";
+        } else if (result.ms >= SLOW_THRESHOLD_MS) {
+          chip.classList.add("test-slow");
+          if (msEl) msEl.textContent = `${result.ms}ms`;
+        } else {
+          chip.classList.add("test-pass");
+          if (msEl) msEl.textContent = `${result.ms}ms`;
+        }
+      }
+    }
+
+    function showTestResultsModal(allResults) {
+      const good = [], slow = [], failed = [];
+      for (const r of allResults) {
+        if (!r.ok) failed.push(r);
+        else if (r.ms >= SLOW_THRESHOLD_MS) slow.push(r);
+        else good.push(r);
+      }
+
+      const hasIssues = failed.length > 0 || slow.length > 0;
+      if (!hasIssues) {
+        showToast(`All ${good.length} proxies passed`, { type: "success" });
+        return;
+      }
+
+      const stats = `
+        <div style="display:flex;gap:10px;margin-bottom:16px;flex-wrap:wrap">
+          <div style="flex:1;min-width:70px;text-align:center;padding:10px 8px;border-radius:10px;background:rgba(76,175,80,0.1)">
+            <div style="font-size:22px;font-weight:700;color:#4caf50">${good.length}</div>
+            <div style="font-size:11px;color:var(--muted)">healthy</div>
+          </div>
+          ${slow.length ? `<div style="flex:1;min-width:70px;text-align:center;padding:10px 8px;border-radius:10px;background:rgba(255,152,0,0.1)">
+            <div style="font-size:22px;font-weight:700;color:#ff9800">${slow.length}</div>
+            <div style="font-size:11px;color:var(--muted)">slow</div>
+          </div>` : ""}
+          ${failed.length ? `<div style="flex:1;min-width:70px;text-align:center;padding:10px 8px;border-radius:10px;background:rgba(255,80,80,0.1)">
+            <div style="font-size:22px;font-weight:700;color:#ff6b6b">${failed.length}</div>
+            <div style="font-size:11px;color:var(--muted)">failed</div>
+          </div>` : ""}
+        </div>`;
+
+      let listHtml = "";
+      if (failed.length) {
+        listHtml += `<div style="font-size:11px;font-weight:600;color:#ff6b6b;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px">Failed</div>`;
+        listHtml += failed.map(r => buildProxyResultRow(r, "failed")).join("");
+      }
+      if (slow.length) {
+        listHtml += `<div style="font-size:11px;font-weight:600;color:#ff9800;text-transform:uppercase;letter-spacing:0.5px;margin:${failed.length ? "10px" : "0"} 0 4px">Slow (&gt;${SLOW_THRESHOLD_MS / 1000}s)</div>`;
+        listHtml += slow.map(r => buildProxyResultRow(r, "slow")).join("");
+      }
+
+      const resultsBox = `
+        <div class="srv-proxy-results-scroll">
+          ${listHtml}
+        </div>`;
+
+      const checkboxes = `
+        <div style="display:flex;flex-direction:column;gap:8px">
+          ${failed.length ? `<label class="srv-proxy-check" style="cursor:pointer">
+            <input type="checkbox" id="ptr-remove-failed" checked />
+            <span>Remove <strong>${failed.length}</strong> failed proxy${failed.length !== 1 ? "es" : ""}</span>
+          </label>` : ""}
+          ${slow.length ? `<label class="srv-proxy-check" style="cursor:pointer">
+            <input type="checkbox" id="ptr-remove-slow" />
+            <span>Remove <strong>${slow.length}</strong> slow proxy${slow.length !== 1 ? "es" : ""}</span>
+          </label>` : ""}
+        </div>`;
+
+      openConfirm({
+        title: "Proxy Test Results",
+        body: stats + resultsBox + checkboxes,
+        confirmText: "Remove Selected",
+        confirmClass: "btn-ghost-red",
+        showCancel: true,
+        onConfirm: () => {
+          const removeFailed = document.getElementById("ptr-remove-failed")?.checked;
+          const removeSlow = document.getElementById("ptr-remove-slow")?.checked;
+          const toRemove = new Set();
+          if (removeFailed) failed.forEach(r => toRemove.add(r.proxy));
+          if (removeSlow) slow.forEach(r => toRemove.add(r.proxy));
+          if (toRemove.size) {
+            const chipEls = srvProxyChips.querySelectorAll(".srv-proxy-chip-item");
+            chipEls.forEach(el => { if (toRemove.has(el.dataset.proxy)) el.remove(); });
+            refreshStatusChip();
+            saveProxySettings();
+            showToast(`Removed ${toRemove.size} proxy${toRemove.size !== 1 ? "es" : ""}`, { type: "success" });
+          }
+        },
+      });
+    }
+
+    // ── Proxy test streaming state ──
+    let _proxyTestRunning = false;
+    let _proxyTestResults = [];
+
+    function setTestButton(mode) {
+      if (!srvProxyTest) return;
+      if (mode === "running") {
+        _proxyTestRunning = true;
+        srvProxyTest.disabled = false;
+        srvProxyTest.textContent = "Stop";
+        srvProxyTest.classList.add("btn-ghost-red");
+        srvProxyTest.classList.remove("btn-outline");
+      } else {
+        _proxyTestRunning = false;
+        srvProxyTest.disabled = false;
+        srvProxyTest.textContent = "Test All";
+        srvProxyTest.classList.remove("btn-ghost-red");
+        srvProxyTest.classList.add("btn-outline");
+      }
+    }
+
+    function handleProxyTestEvent(payload) {
+      if (payload.type === "started") {
+        _proxyTestResults = [];
+        setTestButton("running");
+        showProxyProgress(0, payload.total);
+        const chipEls = srvProxyChips.querySelectorAll(".srv-proxy-chip-item");
+        chipEls.forEach(el => {
+          el.classList.remove("test-pass", "test-fail", "test-slow");
+          el.classList.add("test-loading");
+          const ms = el.querySelector(".srv-proxy-chip-ms");
+          if (ms) ms.textContent = "testing…";
+          else {
+            const badge = document.createElement("span");
+            badge.className = "srv-proxy-chip-ms";
+            badge.textContent = "testing…";
+            el.insertBefore(badge, el.querySelector(".srv-proxy-chip-x"));
+          }
+        });
+      }
+
+      if (payload.type === "progress") {
+        showProxyProgress(payload.current, payload.total);
+        if (payload.results) {
+          _proxyTestResults.push(...payload.results);
+          applyBatchResultsToChips(payload.results);
+        }
+      }
+
+      if (payload.type === "complete") {
+        setTestButton("idle");
+        hideProxyProgress();
+        const allResults = payload.results || _proxyTestResults;
+        showTestResultsModal(allResults);
+      }
+
+      if (payload.type === "stopped") {
+        setTestButton("idle");
+        hideProxyProgress();
+        // Clear loading state from untested chips
+        srvProxyChips.querySelectorAll(".srv-proxy-chip-item.test-loading").forEach(el => {
+          el.classList.remove("test-loading");
+          const ms = el.querySelector(".srv-proxy-chip-ms");
+          if (ms) ms.remove();
+        });
+        if (_proxyTestResults.length) {
+          showTestResultsModal(_proxyTestResults);
+        } else {
+          showToast("Proxy test stopped", { type: "success" });
+        }
+      }
+    }
+
+    async function testAllProxies() {
+      const proxies = getProxyChipValues();
+      if (!proxies.length) { showToast("No proxies to test", { type: "error" }); return; }
+
+      srvProxyTest.disabled = true;
+      try {
+        const r = await fetch("/api/server/proxies/test", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ proxies }),
+        });
+        const j = await r.json();
+        if (!j.ok) {
+          showToast(j.error || "Failed to start test", { type: "error" });
+          setTestButton("idle");
+        }
+      } catch (e) {
+        console.error(e);
+        showToast("Failed to start proxy test", { type: "error" });
+        setTestButton("idle");
+      }
+    }
+
+    async function stopProxyTest() {
+      srvProxyTest.disabled = true;
+      try {
+        await fetch("/api/server/proxies/test/stop", { method: "POST" });
+      } catch (e) {
+        console.error(e);
+        setTestButton("idle");
+        hideProxyProgress();
+      }
+    }
+
+    // Check if a test is already running on page load
+    async function checkProxyTestStatus() {
+      try {
+        const r = await fetch("/api/server/proxies/test/status");
+        const j = await r.json();
+        if (j.ok && j.running) {
+          setTestButton("running");
+          showProxyProgress(0, 0);
+          if (proxyProgressText) proxyProgressText.textContent = "resuming…";
+        }
+      } catch {}
+    }
+
+    if (srvProxyTest) {
+      srvProxyTest.addEventListener("click", () => {
+        if (_proxyTestRunning) stopProxyTest();
+        else testAllProxies();
+      });
+    }
     if (srvProxyClear)      srvProxyClear.addEventListener("click", () => {
       if (!getProxyChipValues().length) return;
       openConfirm({
@@ -5035,6 +5303,7 @@
     }
 
     loadSrvProxies();
+    checkProxyTestStatus();
   });
 
   ["server", "client"].forEach((role) => {

--- a/code/admin/frontend/src/js/scraper.js
+++ b/code/admin/frontend/src/js/scraper.js
@@ -36,13 +36,6 @@
   const scrapesList = $("#sc-scrapes-list");
   const scrapesEmpty = $("#sc-scrapes-empty");
   const scrapesRefresh = $("#sc-scrapes-refresh");
-  const proxyCard = $("#sc-proxy-card");
-  const proxyTextarea = $("#sc-proxy-textarea");
-  const proxyCount = $("#sc-proxy-count");
-  const proxySaveBtn = $("#sc-proxy-save");
-  const proxyClearBtn = $("#sc-proxy-clear");
-  const proxyPrependHttp = $("#sc-proxy-prepend-http");
-  const proxyPrependSocks5 = $("#sc-proxy-prepend-socks5");
   const queueCard = $("#sc-queue-card");
   const queueBody = $("#sc-queue-body");
   const queueList = $("#sc-queue-list");
@@ -403,75 +396,17 @@
     };
   }
 
-  function getProxyLines() {
-    return proxyTextarea.value
-      .split("\n")
-      .map((l) => l.trim())
-      .filter((l) => l.length > 0);
+  async function getProxyLines() {
+    try {
+      const j = await api("/api/scraper/proxies");
+      return j.ok ? (j.proxies || []) : [];
+    } catch { return []; }
   }
-
-  function updateProxyCount() {
-    const n = getProxyLines().length;
-    proxyCount.textContent = n > 0 ? `${n} proxy${n !== 1 ? "ies" : ""}` : "";
-  }
-
-  async function loadProxies() {
-    const j = await api("/api/scraper/proxies");
-    if (j.ok) {
-      proxyTextarea.value = (j.proxies || []).join("\n");
-      updateProxyCount();
-    }
-  }
-
-  async function saveProxies() {
-    const lines = getProxyLines();
-    const j = await api("/api/scraper/proxies", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ proxies: lines }),
-    });
-    if (j.ok) {
-      toast(`Saved ${lines.length} prox${lines.length !== 1 ? "ies" : "y"}`, {
-        type: "success",
-      });
-      updateProxyCount();
-    } else {
-      toast(j.error || "Failed to save proxies", { type: "error" });
-    }
-  }
-
-  proxySaveBtn.addEventListener("click", saveProxies);
-
-  proxyClearBtn.addEventListener("click", async () => {
-    proxyTextarea.value = "";
-    await saveProxies();
-  });
-
-  proxyTextarea.addEventListener("input", updateProxyCount);
-
-  /** Prepend a scheme (http:// or socks5://) to every line that doesn't already have one. */
-  function prependScheme(scheme) {
-    const lines = proxyTextarea.value.split("\n");
-    proxyTextarea.value = lines
-      .map((line) => {
-        const l = line.trim();
-        if (!l) return l;
-        if (l.includes("://")) return l;
-        return `${scheme}${l}`;
-      })
-      .join("\n");
-    updateProxyCount();
-  }
-
-  proxyPrependHttp.addEventListener("click", () => prependScheme("http://"));
-  proxyPrependSocks5.addEventListener("click", () =>
-    prependScheme("socks5://")
-  );
 
   /* ── Queue helpers ── */
 
-  function getScraperPayload() {
-    const proxies = getProxyLines();
+  async function getScraperPayload() {
+    const proxies = await getProxyLines();
     return {
       guild_id: guildIdIn.value.trim(),
       include_username: $("#sc-opt-username").checked,
@@ -570,7 +505,7 @@
     }
 
     queueBtn.disabled = true;
-    const payload = getScraperPayload();
+    const payload = await getScraperPayload();
 
     const j = await api("/api/scraper/queue/add", {
       method: "POST",
@@ -615,7 +550,7 @@
     }
 
     startBtn.disabled = true;
-    const payload = getScraperPayload();
+    const payload = await getScraperPayload();
 
     const j = await api("/api/scraper/start", {
       method: "POST",
@@ -922,7 +857,6 @@
   async function init() {
     try {
       await loadTokens();
-      await loadProxies();
       await loadScrapes();
       await checkStatus();
     } catch (e) {

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -2469,6 +2469,51 @@ body {
 }
 #confirm-modal .modal-content {
   transform: translateY(-4vh);
+  max-height: 80vh;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent) transparent;
+}
+#confirm-modal .modal-content::-webkit-scrollbar {
+  width: 12px;
+}
+#confirm-modal .modal-content::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 12px;
+}
+#confirm-modal .modal-content::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, var(--primary), var(--primary-700));
+  border: 2px solid var(--bg, #1a1028);
+  border-radius: 12px;
+}
+#confirm-modal .modal-content::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, var(--primary-600), var(--primary-700));
+}
+.srv-proxy-results-scroll {
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #140b26;
+  border: 1px solid var(--border);
+  margin-bottom: 14px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent) transparent;
+}
+.srv-proxy-results-scroll::-webkit-scrollbar {
+  width: 12px;
+}
+.srv-proxy-results-scroll::-webkit-scrollbar-track {
+  background: #140b26;
+  border-radius: 12px;
+}
+.srv-proxy-results-scroll::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, var(--primary), var(--primary-700));
+  border: 2px solid #140b26;
+  border-radius: 12px;
+}
+.srv-proxy-results-scroll::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, var(--primary-600), var(--primary-700));
 }
 @media (max-height: 640px) {
   #confirm-modal .modal-content {
@@ -10810,6 +10855,11 @@ body.page-forwarding .fwd-no-match-sub {
 .srv-proxy-hint-row .srv-proxy-hint {
   margin-bottom: 0;
 }
+.srv-proxy-hint-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
 .srv-proxy-hint {
   font-size: 12px;
   color: var(--muted);
@@ -10881,6 +10931,38 @@ body.page-forwarding .fwd-no-match-sub {
   color: #fff;
   background: rgba(255, 80, 80, 0.7);
 }
+.srv-proxy-chip-item.test-pass {
+  border-color: rgba(76, 175, 80, 0.4);
+  background: rgba(76, 175, 80, 0.08);
+}
+.srv-proxy-chip-item.test-fail {
+  border-color: rgba(255, 80, 80, 0.4);
+  background: rgba(255, 80, 80, 0.08);
+}
+.srv-proxy-chip-item.test-slow {
+  border-color: rgba(255, 152, 0, 0.4);
+  background: rgba(255, 152, 0, 0.08);
+}
+.srv-proxy-chip-item.test-loading {
+  opacity: 0.6;
+}
+.srv-proxy-chip-ms {
+  font-size: 10px;
+  color: var(--muted);
+  opacity: 0.7;
+}
+.srv-proxy-chip-item.test-pass .srv-proxy-chip-ms {
+  color: #4caf50;
+  opacity: 1;
+}
+.srv-proxy-chip-item.test-fail .srv-proxy-chip-ms {
+  color: #ff6b6b;
+  opacity: 1;
+}
+.srv-proxy-chip-item.test-slow .srv-proxy-chip-ms {
+  color: #ff9800;
+  opacity: 1;
+}
 .srv-proxy-chip-x {
   display: inline-flex;
   align-items: center;
@@ -10915,6 +10997,33 @@ body.page-forwarding .fwd-no-match-sub {
 .srv-proxy-chips-input::placeholder {
   color: var(--muted);
   opacity: 0.5;
+}
+.srv-proxy-progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.srv-proxy-progress-bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+.srv-proxy-progress-fill {
+  height: 100%;
+  width: 0%;
+  border-radius: 3px;
+  background: linear-gradient(90deg, var(--primary, #8b5cf6), var(--accent, #a78bfa));
+  transition: width 0.3s ease;
+}
+.srv-proxy-progress-text {
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+  min-width: 70px;
+  text-align: right;
 }
 .srv-proxy-rotation-section {
   margin-top: 16px;

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -10792,6 +10792,150 @@ body.page-forwarding .fwd-no-match-sub {
   color: var(--muted);
   background: rgba(255, 255, 255, 0.06);
 }
+.srv-proxy-settings-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 500;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  margin-left: 6px;
+}
+.srv-proxy-settings-btn:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+.proxy-settings-content {
+  width: min(480px, 92vw) !important;
+}
+.proxy-settings-body {
+  padding: 4px 20px 20px;
+}
+.proxy-settings-group {
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+}
+.proxy-settings-group:last-of-type {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+.proxy-settings-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--accent, #a78bfa);
+  margin-bottom: 4px;
+}
+.proxy-settings-group-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+.proxy-settings-desc {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0 0 12px;
+  line-height: 1.4;
+}
+.proxy-settings-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.proxy-settings-field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 13px;
+  color: var(--text);
+  padding: 6px 10px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  transition: background 0.12s ease;
+}
+.proxy-settings-field:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+.proxy-settings-label {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.proxy-settings-label > span:first-child {
+  font-weight: 500;
+}
+.proxy-settings-sublabel {
+  font-size: 11px;
+  color: var(--muted);
+  opacity: 0.7;
+}
+.proxy-settings-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.ps-input {
+  width: 64px;
+  height: 32px;
+  padding: 0 8px;
+  font-size: 13px;
+  text-align: center;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: #140b26;
+  color: var(--text);
+  outline: 0;
+  transition: border-color 0.15s ease;
+  -moz-appearance: textfield;
+}
+.ps-input::-webkit-inner-spin-button,
+.ps-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.ps-input:focus {
+  border-color: var(--brand, var(--accent));
+}
+.proxy-settings-unit {
+  font-size: 11px;
+  color: var(--muted);
+  min-width: 48px;
+}
+.proxy-settings-footer-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+.ps-reset-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+.ps-reset-btn:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.15);
+}
 .srv-proxy-chip:empty {
   display: none;
 }

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -10737,28 +10737,26 @@ body.page-forwarding .fwd-no-match-sub {
   margin: 0;
   font-size: 15px;
 }
-.srv-proxy-status {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--muted);
+.srv-proxy-chip {
   margin-left: auto;
-}
-.srv-proxy-status:empty {
-  display: none;
-}
-.srv-proxy-status.is-on {
-  color: #4caf50;
-}
-.srv-proxy-status.is-warn {
-  color: #ff9800;
-}
-.srv-proxy-count {
   font-size: 11px;
   font-weight: 600;
+  line-height: 1;
+  padding: 4px 10px;
+  border-radius: 20px;
   color: var(--muted);
+  background: rgba(255, 255, 255, 0.06);
 }
-.srv-proxy-count:empty {
+.srv-proxy-chip:empty {
   display: none;
+}
+.srv-proxy-chip.is-on {
+  color: #4caf50;
+  background: rgba(76, 175, 80, 0.12);
+}
+.srv-proxy-chip.is-warn {
+  color: #ff9800;
+  background: rgba(255, 152, 0, 0.12);
 }
 .srv-proxy-body {
   margin-top: 14px;
@@ -10766,7 +10764,7 @@ body.page-forwarding .fwd-no-match-sub {
 .srv-proxy-toggle-row {
   margin-bottom: 12px;
 }
-.srv-proxy-toggle-label {
+.srv-proxy-check {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -10776,11 +10774,41 @@ body.page-forwarding .fwd-no-match-sub {
   color: var(--text);
   user-select: none;
 }
-.srv-proxy-toggle-label input[type='checkbox'] {
-  width: 15px;
-  height: 15px;
-  accent-color: var(--brand, var(--accent));
+.srv-proxy-check input[type='checkbox'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  border: 1.5px solid var(--border, #2c1d4a);
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.04);
   cursor: pointer;
+  position: relative;
+  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+  flex-shrink: 0;
+}
+.srv-proxy-check input[type='checkbox']:hover {
+  border-color: var(--accent, #a78bfa);
+}
+.srv-proxy-check input[type='checkbox']:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.18);
+}
+.srv-proxy-check input[type='checkbox']:checked {
+  background: var(--primary, #8b5cf6);
+  border-color: var(--primary, #8b5cf6);
+}
+.srv-proxy-hint-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.srv-proxy-hint-row .srv-proxy-hint {
+  margin-bottom: 0;
 }
 .srv-proxy-hint {
   font-size: 12px;
@@ -10794,58 +10822,157 @@ body.page-forwarding .fwd-no-match-sub {
   padding: 1px 5px;
   border-radius: 4px;
 }
-.srv-proxy-textarea {
-  width: 100%;
-  min-height: 90px;
-  max-height: 260px;
-  resize: vertical;
+.srv-proxy-chips {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #140b26;
+  min-height: 44px;
+  max-height: 220px;
+  overflow-y: auto;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent) transparent;
+}
+.srv-proxy-chips:focus-within {
+  border-color: var(--brand, var(--accent));
+  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.12);
+}
+.srv-proxy-chips::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+.srv-proxy-chips::-webkit-scrollbar-track {
+  background: #140b26;
+  border-radius: 12px;
+}
+.srv-proxy-chips::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, var(--primary), var(--primary-700));
+  border: 2px solid #140b26;
+  border-radius: 12px;
+}
+.srv-proxy-chips::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, var(--primary-600), var(--primary-700));
+}
+.srv-proxy-chip-item {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 6px;
+  padding: 4px 8px 4px 10px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 12px;
-  line-height: 1.6;
-  padding: 10px 12px;
+  color: var(--text);
+  line-height: 1.3;
+  cursor: default;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.srv-proxy-chip-item:hover {
+  background: rgba(255, 80, 80, 0.1);
+  border-color: rgba(255, 80, 80, 0.3);
+}
+.srv-proxy-chip-item:hover .srv-proxy-chip-x {
+  color: #fff;
+  background: rgba(255, 80, 80, 0.7);
+}
+.srv-proxy-chip-x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.srv-proxy-chip-x:hover {
+  color: #fff;
+  background: rgba(255, 80, 80, 0.6);
+}
+.srv-proxy-chips-input {
+  width: 100%;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  padding: 4px 4px;
+  flex-shrink: 0;
+}
+.srv-proxy-chips-input::placeholder {
+  color: var(--muted);
+  opacity: 0.5;
+}
+.srv-proxy-rotation-section {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+}
+.srv-proxy-rotation-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.srv-proxy-interval-inline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.srv-proxy-interval-inline.is-hidden {
+  display: none;
+}
+.srv-proxy-interval-input,
+.srv-proxy-interval-select {
+  height: 34px;
+  padding: 0 10px;
+  font-size: 13px;
   border-radius: 10px;
   border: 1px solid var(--border);
   background: #140b26;
   color: var(--text);
   outline: 0;
   transition: border-color 0.15s ease;
-  scrollbar-width: thin;
-  scrollbar-color: var(--accent) transparent;
 }
-.srv-proxy-textarea::-webkit-scrollbar {
-  width: 12px;
-  height: 12px;
+.srv-proxy-interval-input {
+  width: 68px;
+  text-align: center;
+  -moz-appearance: textfield;
 }
-.srv-proxy-textarea::-webkit-scrollbar-track {
-  background: #140b26;
-  border-radius: 12px;
+.srv-proxy-interval-input::-webkit-inner-spin-button,
+.srv-proxy-interval-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
-.srv-proxy-textarea::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, var(--primary), var(--primary-700));
-  border: 2px solid #140b26;
-  border-radius: 12px;
+.srv-proxy-interval-select {
+  cursor: pointer;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding-right: 26px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%239e95b7' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
 }
-.srv-proxy-textarea::-webkit-scrollbar-thumb:hover {
-  background: linear-gradient(180deg, var(--primary-600), var(--primary-700));
-}
-.srv-proxy-textarea:focus {
+.srv-proxy-interval-input:focus,
+.srv-proxy-interval-select:focus {
   border-color: var(--brand, var(--accent));
 }
-.srv-proxy-textarea::placeholder {
-  color: var(--muted);
-  opacity: 0.55;
-}
-.srv-proxy-actions {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  margin-top: 10px;
-}
-.srv-proxy-separator {
-  width: 1px;
-  height: 18px;
-  background: var(--border, rgba(255, 255, 255, 0.12));
-  margin: 0 2px;
+.srv-proxy-rotation-hint {
+  margin-top: 6px;
+  margin-bottom: 0;
 }
 
 .sc-log-card .log-output {

--- a/code/admin/templates/index.html
+++ b/code/admin/templates/index.html
@@ -457,37 +457,51 @@
       <div id="guild-mapping-list" class="guild-mapping-list"></div>
     </div>
 
-    <!-- ─── Server Proxy Rotation ─── -->
+    <!-- ─── Proxy ─── -->
     <details class="card srv-proxy-card" id="srv-proxy-card">
       <summary class="srv-proxy-summary">
-        <h3>Proxy Rotation</h3>
-        <span class="srv-proxy-status" id="srv-proxy-status"></span>
-        <span class="srv-proxy-count" id="srv-proxy-count"></span>
+        <h3>Proxy</h3>
+        <span class="srv-proxy-chip" id="srv-proxy-status"></span>
       </summary>
       <div class="srv-proxy-body">
         <div class="srv-proxy-toggle-row">
-          <label class="srv-proxy-toggle-label" for="srv-proxy-toggle">
+          <label class="srv-proxy-check" for="srv-proxy-toggle">
             <input type="checkbox" id="srv-proxy-toggle" />
-            <span>Enable proxy rotation for structure sync</span>
+            <span>Enable proxies for client</span>
           </label>
         </div>
-        <p class="srv-proxy-hint">
-          When enabled, every Discord API call during structure sync
-          (channel create, webhook create, guild edit, etc.) is routed through a
-          rotating proxy and rate limiting is bypassed — syncs complete much faster.<br>
-          Paste one proxy per line. Examples:
-          <code>host:port</code>, <code>host:port:user:pass</code>,
-          <code>user:pass@host:port</code>
-        </p>
-        <textarea class="input srv-proxy-textarea" id="srv-proxy-textarea"
-                  placeholder="82.27.104.216:25208:user:pass&#10;1.2.3.4:8080&#10;user:pass@5.6.7.8:3128"
-                  rows="5" spellcheck="false"></textarea>
-        <div class="srv-proxy-actions">
-          <button class="btn btn-primary btn-xs" id="srv-proxy-save" type="button">Save</button>
+        <div class="srv-proxy-hint-row">
+          <p class="srv-proxy-hint">
+            Paste one or more proxies &mdash;
+            <code>host:port</code> &middot; <code>host:port:user:pass</code> &middot;
+            <code>user:pass@host:port</code>
+          </p>
           <button class="btn btn-ghost btn-xs" id="srv-proxy-clear" type="button">Clear</button>
-          <span class="srv-proxy-separator"></span>
-          <button class="btn btn-outline btn-xs" id="srv-proxy-prepend-http" type="button">+ http://</button>
-          <button class="btn btn-outline btn-xs" id="srv-proxy-prepend-socks5" type="button">+ socks5://</button>
+        </div>
+        <div class="srv-proxy-chips" id="srv-proxy-chips">
+          <input type="text" class="srv-proxy-chips-input" id="srv-proxy-chips-input"
+                 placeholder="Paste or type a proxy and press Enter" spellcheck="false" />
+        </div>
+
+        <div class="srv-proxy-rotation-section">
+          <div class="srv-proxy-rotation-row">
+            <label class="srv-proxy-check" for="srv-proxy-rotation-toggle">
+              <input type="checkbox" id="srv-proxy-rotation-toggle" />
+              <span>Rotate every</span>
+            </label>
+            <div class="srv-proxy-interval-inline" id="srv-proxy-rotation-controls">
+              <input type="number" id="srv-proxy-interval" class="input srv-proxy-interval-input"
+                     min="1" max="1440" value="30" />
+              <select id="srv-proxy-interval-unit" class="input srv-proxy-interval-select">
+                <option value="60" selected>minutes</option>
+                <option value="3600">hours</option>
+              </select>
+            </div>
+          </div>
+          <p class="srv-proxy-hint srv-proxy-rotation-hint">
+            Automatically switches to the next proxy after the set duration.
+            When off, one proxy is used until it fails.
+          </p>
         </div>
       </div>
     </details>

--- a/code/admin/templates/index.html
+++ b/code/admin/templates/index.html
@@ -462,6 +462,14 @@
       <summary class="srv-proxy-summary">
         <h3>Proxy</h3>
         <span class="srv-proxy-chip" id="srv-proxy-status"></span>
+        <button type="button" class="srv-proxy-settings-btn" id="srv-proxy-settings-btn" title="Proxy Settings" onclick="event.preventDefault()">
+          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"/>
+            <path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
+          </svg>
+          Settings
+        </button>
       </summary>
       <div class="srv-proxy-body">
         <div class="srv-proxy-toggle-row">
@@ -514,6 +522,84 @@
         </div>
       </div>
     </details>
+
+    <!-- ─── Proxy Settings Modal ─── -->
+    <div id="proxy-settings-modal" class="modal" aria-hidden="true">
+      <div class="modal-backdrop"></div>
+      <div class="modal-content proxy-settings-content" role="dialog" aria-modal="true">
+        <div class="modal-header">
+          <h4 class="modal-title">Proxy Settings</h4>
+          <button type="button" id="proxy-settings-close" class="icon-btn verify-close" aria-label="Close">&#10005;</button>
+        </div>
+        <div class="proxy-settings-body">
+          <div class="proxy-settings-group">
+            <div class="proxy-settings-group-header">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/>
+              </svg>
+              <h5 class="proxy-settings-group-title">Failover</h5>
+            </div>
+            <p class="proxy-settings-desc">If your proxy drops or goes down, the client detects it automatically and switches to the next available proxy. A failed proxy is temporarily blocked to avoid reconnecting to it immediately.</p>
+            <div class="proxy-settings-fields">
+              <label class="proxy-settings-field">
+                <div class="proxy-settings-label">
+                  <span>Suspend duration</span>
+                  <span class="proxy-settings-sublabel">How long a failed proxy stays blocked before retrying</span>
+                </div>
+                <div class="proxy-settings-input-wrap">
+                  <input type="number" id="ps-suspend-duration" class="input ps-input" min="10" max="3600" value="300" />
+                  <span class="proxy-settings-unit">sec</span>
+                </div>
+              </label>
+            </div>
+          </div>
+          <div class="proxy-settings-group">
+            <div class="proxy-settings-group-header">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m15 6 2 2 4-4"/>
+                <path d="M2 12h20A10 10 0 1 1 12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 4-10"/>
+              </svg>
+              <h5 class="proxy-settings-group-title">Proxy Testing</h5>
+            </div>
+            <p class="proxy-settings-desc">When you click "Test All", every proxy in your list is checked by connecting to Discord through it. These settings control how many are tested at once and what counts as too slow.</p>
+            <div class="proxy-settings-fields">
+              <label class="proxy-settings-field">
+                <div class="proxy-settings-label">
+                  <span>Batch size</span>
+                  <span class="proxy-settings-sublabel">Proxies tested at the same time</span>
+                </div>
+                <div class="proxy-settings-input-wrap">
+                  <input type="number" id="ps-test-batch" class="input ps-input" min="5" max="500" value="50" />
+                  <span class="proxy-settings-unit">concurrent</span>
+                </div>
+              </label>
+              <label class="proxy-settings-field">
+                <div class="proxy-settings-label">
+                  <span>Slow threshold</span>
+                  <span class="proxy-settings-sublabel">Flag proxies slower than this</span>
+                </div>
+                <div class="proxy-settings-input-wrap">
+                  <input type="number" id="ps-slow-threshold" class="input ps-input" min="1" max="30" value="3" />
+                  <span class="proxy-settings-unit">sec</span>
+                </div>
+              </label>
+            </div>
+          </div>
+          <div class="proxy-settings-footer-row">
+            <button type="button" class="ps-reset-btn" id="ps-reset-defaults">
+              <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+                <path d="M3 3v5h5"/>
+              </svg>
+              Reset to Defaults
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
 
     <div id="log-modal" class="modal" aria-hidden="true">
       <div class="modal-backdrop"></div>

--- a/code/admin/templates/index.html
+++ b/code/admin/templates/index.html
@@ -476,7 +476,16 @@
             <code>host:port</code> &middot; <code>host:port:user:pass</code> &middot;
             <code>user:pass@host:port</code>
           </p>
-          <button class="btn btn-ghost btn-xs" id="srv-proxy-clear" type="button">Clear</button>
+          <div class="srv-proxy-hint-actions">
+            <button class="btn btn-ghost-green btn-xs" id="srv-proxy-test" type="button">Test All</button>
+            <button class="btn btn-ghost-red btn-xs" id="srv-proxy-clear" type="button">Clear</button>
+          </div>
+        </div>
+        <div class="srv-proxy-progress" id="srv-proxy-progress" style="display:none">
+          <div class="srv-proxy-progress-bar">
+            <div class="srv-proxy-progress-fill" id="srv-proxy-progress-fill"></div>
+          </div>
+          <span class="srv-proxy-progress-text" id="srv-proxy-progress-text"></span>
         </div>
         <div class="srv-proxy-chips" id="srv-proxy-chips">
           <input type="text" class="srv-proxy-chips-input" id="srv-proxy-chips-input"

--- a/code/admin/templates/scraper.html
+++ b/code/admin/templates/scraper.html
@@ -284,27 +284,15 @@
       </section>
     </div>
 
-    <!-- ─── Proxy List (collapsible) ─── -->
-    <details class="card scraper-card sc-proxy-card" id="sc-proxy-card">
-      <summary class="sc-proxy-summary">
-        <h3>Proxies</h3>
-        <span class="sc-proxy-count" id="sc-proxy-count"></span>
-      </summary>
-      <div class="sc-proxy-body">
-        <p class="sc-proxy-hint">Paste one proxy per line. Any format works — use the buttons below to add a prefix.<br>
-          Examples: <code>host:port</code>, <code>host:port:user:pass</code>, <code>user:pass@host:port</code></p>
-        <textarea class="input sc-proxy-textarea" id="sc-proxy-textarea"
-                  placeholder="82.27.104.216:25208:user:pass&#10;1.2.3.4:8080&#10;user:pass@5.6.7.8:3128"
-                  rows="6" spellcheck="false"></textarea>
-        <div class="sc-proxy-actions">
-          <button class="btn btn-primary btn-xs" id="sc-proxy-save" type="button">Save</button>
-          <button class="btn btn-ghost btn-xs" id="sc-proxy-clear" type="button">Clear</button>
-          <span class="sc-proxy-separator"></span>
-          <button class="btn btn-outline btn-xs" id="sc-proxy-prepend-http" type="button">+ http://</button>
-          <button class="btn btn-outline btn-xs" id="sc-proxy-prepend-socks5" type="button">+ socks5://</button>
-        </div>
-      </div>
-    </details>
+    <!-- ─── Proxy Info ─── -->
+    <div class="card scraper-card sc-proxy-card" id="sc-proxy-card">
+      <h3 style="margin:0 0 8px">Proxies</h3>
+      <p class="sc-proxy-hint" style="margin:0">
+        The scraper uses the shared proxy list from the
+        <a href="/" style="color:var(--accent);text-decoration:underline">Configuration</a> page.
+        Add or manage proxies in the <strong>Proxy</strong> card there.
+      </p>
+    </div>
 
     <!-- ─── Scrape Queue ─── -->
     <section class="card scraper-card" id="sc-queue-card" hidden>

--- a/code/admin/templates/scraper.html
+++ b/code/admin/templates/scraper.html
@@ -290,7 +290,7 @@
       <p class="sc-proxy-hint" style="margin:0">
         The scraper uses the shared proxy list from the
         <a href="/" style="color:var(--accent);text-decoration:underline">Configuration</a> page.
-        Add or manage proxies in the <strong>Proxy</strong> card there.
+        Add or manage proxies in the <strong>Proxy</strong> section.
       </p>
     </div>
 

--- a/code/client/client.py
+++ b/code/client/client.py
@@ -39,6 +39,7 @@ from client.export_runners import (
     DmHistoryExporter,
 )
 from client.forwarding import ForwardingManager
+from client.proxy_rotator import ProxyRotator, patch_discord_http
 
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -92,6 +93,7 @@ class ClientListener:
         self.msg = MessageUtils(self.bot)
         self._sync_task: Optional[asyncio.Task] = None
         self._ws_task: Optional[asyncio.Task] = None
+        self._proxy_rotation_task: Optional[asyncio.Task] = None
         self._m_user = re.compile(r"<@!?(\d+)>")
         self.scraper = getattr(self, "scraper", None)
         self._scrape_lock = getattr(self, "_scrape_lock", asyncio.Lock())
@@ -153,6 +155,9 @@ class ClientListener:
         self.runner = ExportMessagesRunner(
             bot=self.bot, ws=self.ws, msg_serializer=self.msg.serialize, logger=logger
         )
+        self.proxy_rotator = ProxyRotator()
+        self._init_proxy_rotator()
+
         self.backfill = BackfillEngine(self, logger=logger)
         self._bf_max = int(os.getenv("BACKFILL_MAX_CONCURRENT", "2"))
         self._bf_queue: asyncio.Queue[tuple[int, dict]] = asyncio.Queue(
@@ -188,6 +193,23 @@ class ClientListener:
             )
         except Exception:
             logger.exception("Failed reloading mapped origins")
+
+    def _init_proxy_rotator(self) -> None:
+        """Load proxy list and configure rotation from DB flags."""
+        self.proxy_rotator.reload()
+        enabled = (
+            self.db.get_config("ENABLE_CLIENT_PROXIES", "") or ""
+        ).strip().lower() in ("1", "true", "yes")
+        self.proxy_rotator.set_enabled(enabled)
+
+        interval_raw = (
+            self.db.get_config("PROXY_ROTATION_INTERVAL", "") or ""
+        ).strip()
+        try:
+            interval_sec = int(interval_raw) if interval_raw else 0
+        except (ValueError, TypeError):
+            interval_sec = 0
+        self.proxy_rotator.set_rotation_interval(interval_sec)
 
     async def _on_ws(self, msg: dict) -> dict | None:
         """
@@ -883,6 +905,12 @@ class ClientListener:
     async def on_ready(self):
         await self.forwarding.start()
         self._reload_mapped_ids()
+
+        patch_discord_http(self.bot, self.proxy_rotator)
+        if self._proxy_rotation_task is None:
+            self._proxy_rotation_task = asyncio.create_task(
+                self.proxy_rotator.run_rotation_loop()
+            )
 
         asyncio.create_task(self.config.setup_release_watcher(self, should_dm=False))
         self.ui_controller.start()
@@ -2628,6 +2656,8 @@ class ClientListener:
         Runs the Copycord client.
         """
         logger.info("[✨] Starting Copycord Client %s", CURRENT_VERSION)
+        if self.proxy_rotator.enabled:
+            self.proxy_rotator.next()
         loop = asyncio.get_event_loop()
 
         try:

--- a/code/client/client.py
+++ b/code/client/client.py
@@ -39,7 +39,7 @@ from client.export_runners import (
     DmHistoryExporter,
 )
 from client.forwarding import ForwardingManager
-from client.proxy_rotator import ProxyRotator, patch_discord_http
+from client.proxy_rotator import ProxyRotator
 
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -89,7 +89,11 @@ class ClientListener:
         self.db = DBManager(self.config.DB_PATH)
         self._mapped_original_ids: set[int] = set(self.db.get_all_original_guild_ids())
         self.start_time = datetime.now(timezone.utc)
-        self.bot = commands.Bot(command_prefix="!", self_bot=True)
+        self.proxy_rotator = ProxyRotator()
+        self._init_proxy_rotator()
+        self._initial_proxy = self.proxy_rotator.next() if self.proxy_rotator.enabled else None
+        self.bot = commands.Bot(command_prefix="!", self_bot=True, proxy=self._initial_proxy)
+        self.proxy_rotator.on_rotate = self._on_proxy_rotate
         self.msg = MessageUtils(self.bot)
         self._sync_task: Optional[asyncio.Task] = None
         self._ws_task: Optional[asyncio.Task] = None
@@ -155,9 +159,6 @@ class ClientListener:
         self.runner = ExportMessagesRunner(
             bot=self.bot, ws=self.ws, msg_serializer=self.msg.serialize, logger=logger
         )
-        self.proxy_rotator = ProxyRotator()
-        self._init_proxy_rotator()
-
         self.backfill = BackfillEngine(self, logger=logger)
         self._bf_max = int(os.getenv("BACKFILL_MAX_CONCURRENT", "2"))
         self._bf_queue: asyncio.Queue[tuple[int, dict]] = asyncio.Queue(
@@ -210,6 +211,13 @@ class ClientListener:
         except (ValueError, TypeError):
             interval_sec = 0
         self.proxy_rotator.set_rotation_interval(interval_sec)
+
+    def _on_proxy_rotate(self, proxy_url: str) -> None:
+        """Called by the proxy rotator when the active proxy changes."""
+        try:
+            self.bot.http.proxy = proxy_url
+        except Exception:
+            pass
 
     async def _on_ws(self, msg: dict) -> dict | None:
         """
@@ -906,7 +914,6 @@ class ClientListener:
         await self.forwarding.start()
         self._reload_mapped_ids()
 
-        patch_discord_http(self.bot, self.proxy_rotator)
         if self._proxy_rotation_task is None:
             self._proxy_rotation_task = asyncio.create_task(
                 self.proxy_rotator.run_rotation_loop()

--- a/code/client/client.py
+++ b/code/client/client.py
@@ -12,6 +12,7 @@ import asyncio
 import contextlib
 import re
 import signal
+import time
 from datetime import datetime, timezone
 import logging
 from typing import Optional, Any
@@ -39,7 +40,7 @@ from client.export_runners import (
     DmHistoryExporter,
 )
 from client.forwarding import ForwardingManager
-from client.proxy_rotator import ProxyRotator
+from client.proxy_rotator import ProxyRotator, _mask_proxy_url
 
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -110,6 +111,8 @@ class ClientListener:
         self._dm_export_task: asyncio.Task | None = None
         self._dm_export_running: bool = False
         self.bot.event(self.on_ready)
+        self.bot.event(self.on_disconnect)
+        self.bot.event(self.on_resumed)
         self.bot.event(self.on_message)
         self.bot.event(self.on_message_edit)
         self.bot.event(self.on_raw_message_edit)
@@ -203,14 +206,17 @@ class ClientListener:
         ).strip().lower() in ("1", "true", "yes")
         self.proxy_rotator.set_enabled(enabled)
 
-        interval_raw = (
-            self.db.get_config("PROXY_ROTATION_INTERVAL", "") or ""
-        ).strip()
-        try:
-            interval_sec = int(interval_raw) if interval_raw else 0
-        except (ValueError, TypeError):
-            interval_sec = 0
-        self.proxy_rotator.set_rotation_interval(interval_sec)
+        def _db_int(key, default):
+            raw = (self.db.get_config(key, "") or "").strip()
+            try:
+                return int(raw) if raw else default
+            except (ValueError, TypeError):
+                return default
+
+        self.proxy_rotator.set_rotation_interval(
+            _db_int("PROXY_ROTATION_INTERVAL", 0)
+        )
+        self.proxy_rotator.SUSPEND_SECONDS = _db_int("PROXY_SUSPEND_DURATION", 300)
 
     def _on_proxy_rotate(self, proxy_url: str) -> None:
         """Called by the proxy rotator when the active proxy changes."""
@@ -909,6 +915,27 @@ class ClientListener:
             self.sitemap.schedule_sync(None, delay=delay)
         except Exception:
             logger.exception("[sitemap] failed to schedule sync for %s", guild_id)
+
+    async def on_disconnect(self):
+        """Fired when the gateway WebSocket drops."""
+        if not self.proxy_rotator.enabled or not self._initial_proxy:
+            return
+        self.proxy_rotator.report_failure(self.proxy_rotator._current_proxy or "")
+        if self.proxy_rotator._current_proxy and self.proxy_rotator._is_suspended(
+            self.proxy_rotator._current_proxy, time.monotonic()
+        ):
+            safe = _mask_proxy_url(self.proxy_rotator._current_proxy)
+            logger.warning("[🔀] Proxy %s dropped connection, switching", safe)
+            new_proxy = self.proxy_rotator.rotate_now()
+            if new_proxy:
+                self.bot.http.proxy = new_proxy
+            else:
+                logger.warning("[🔀] No healthy proxies available")
+
+    async def on_resumed(self):
+        """Fired when the gateway successfully reconnects."""
+        if self.proxy_rotator.enabled and self.proxy_rotator._current_proxy:
+            self.proxy_rotator.report_success(self.proxy_rotator._current_proxy)
 
     async def on_ready(self):
         await self.forwarding.start()
@@ -2655,8 +2682,53 @@ class ClientListener:
                 else:
                     logger.error("[⛔] No valid backup token available after connection close.")
 
-        except Exception:
-            logger.exception("[⛔] Unexpected error while running client")
+        except Exception as e:
+            if not self._try_next_proxy_on_error(e, token, loop):
+                logger.exception("[⛔] Unexpected error while running client")
+
+    def _is_proxy_error(self, exc: Exception) -> bool:
+        """Check if an exception is a proxy connection failure."""
+        # curl_cffi.requests.exceptions.RequestException inherits OSError
+        if isinstance(exc, (ConnectionError, OSError)):
+            err = str(exc).lower()
+            return "proxy" in err or "curl" in err or "connect" in err or "aborted" in err
+        return False
+
+    def _try_next_proxy_on_error(self, exc: Exception, token: str, loop) -> bool:
+        """If the error is proxy-related, try connecting through other proxies.
+        Returns True if handled (logged), False if caller should handle it."""
+        if not self.proxy_rotator.enabled or not self._initial_proxy:
+            return False
+        if not self._is_proxy_error(exc):
+            return False
+
+        current = self.proxy_rotator._current_proxy or self._initial_proxy
+        safe = _mask_proxy_url(current)
+        logger.warning("[🔀] Proxy %s failed to connect: %s", safe, type(exc).__name__)
+        self.proxy_rotator.report_failure(current)
+
+        for _ in range(self.proxy_rotator.count - 1):
+            new_proxy = self.proxy_rotator.rotate_now()
+            if not new_proxy:
+                break
+            self.bot.http.proxy = new_proxy
+            try:
+                loop.run_until_complete(self.bot.start(token))
+                return True
+            except LoginFailure:
+                logger.error("[⛔] Discord login failed — not a proxy issue")
+                return True
+            except Exception as retry_e:
+                if self._is_proxy_error(retry_e):
+                    safe = _mask_proxy_url(new_proxy)
+                    logger.warning("[🔀] Proxy %s also failed: %s", safe, type(retry_e).__name__)
+                    self.proxy_rotator.report_failure(new_proxy)
+                else:
+                    logger.exception("[⛔] Unexpected error while running client")
+                    return True
+
+        logger.error("[⛔] All proxies failed to connect")
+        return True
 
     def run(self):
         """

--- a/code/client/proxy_rotator.py
+++ b/code/client/proxy_rotator.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     ProxyConnector = None
 
-logger = logging.getLogger("server.proxy_rotator")
+logger = logging.getLogger("client.proxy_rotator")
 
 DATA_DIR = Path(os.getenv("DATA_DIR", "/data"))
 _PROXY_FILE = DATA_DIR / "proxies.txt"
@@ -66,7 +66,14 @@ def _normalise_proxy_url(raw: str) -> Optional[str]:
 
 class ProxyRotator:
     """
-    Thread-safe, round-robin proxy rotator with health tracking.
+    Proxy rotator with health tracking and optional timed rotation.
+
+    By default one proxy is selected and used for all requests.  It only
+    switches when the current proxy is suspended due to failures.
+
+    When ``rotation_interval`` is set (> 0 seconds), the proxy
+    automatically rotates to the next healthy one after the interval
+    elapses.
 
     Proxies that fail repeatedly are temporarily suspended and
     automatically re-tested after a cooldown period.
@@ -93,6 +100,11 @@ class ProxyRotator:
 
         self._health: Dict[str, Dict] = {}
 
+        # Time-based rotation (0 = per-request round-robin)
+        self._rotation_interval: int = 0
+        self._current_proxy: Optional[str] = None
+        self._current_proxy_since: float = 0.0
+
         self.on_all_dead: Optional[callable] = None
 
     @property
@@ -113,6 +125,30 @@ class ProxyRotator:
     def proxies(self) -> List[str]:
         return list(self._proxies)
 
+    @property
+    def rotation_interval(self) -> int:
+        """Rotation interval in seconds (0 = per-request)."""
+        return self._rotation_interval
+
+    def set_rotation_interval(self, seconds: int) -> None:
+        """Set the time-based rotation interval in seconds.
+
+        ``0`` disables timed rotation (sticky — one proxy used until it
+        fails).
+        """
+        seconds = max(0, int(seconds))
+        if seconds != self._rotation_interval:
+            self._rotation_interval = seconds
+            # Reset current assignment so the next call picks fresh
+            self._current_proxy = None
+            self._current_proxy_since = 0.0
+            if seconds:
+                logger.debug(
+                    "[🔀] Proxy rotation interval set to %d seconds", seconds
+                )
+            else:
+                logger.debug("[🔀] Timed rotation disabled (sticky mode)")
+
     def set_enabled(self, on: bool) -> None:
         prev = self._enabled
         self._enabled = bool(on)
@@ -121,12 +157,14 @@ class ProxyRotator:
             return
         if on and self._proxies:
             logger.debug(
-                "[🔀] Server proxy rotation ENABLED (%d proxies)", len(self._proxies)
+                "[🔀] Client proxy rotation ENABLED (%d proxies)", len(self._proxies)
             )
         elif on:
-            logger.warning("[⚠️] Server proxy rotation enabled but NO proxies loaded")
+            logger.warning("[⚠️] Client proxy rotation enabled but NO proxies loaded")
         else:
-            logger.debug("[🔀] Server proxy rotation DISABLED")
+            logger.debug("[🔀] Client proxy rotation DISABLED")
+            self._current_proxy = None
+            self._current_proxy_since = 0.0
 
     def reload(self, proxy_lines: Optional[List[str]] = None) -> int:
         """
@@ -148,16 +186,28 @@ class ProxyRotator:
 
         self._health = {k: v for k, v in self._health.items() if k in normalised}
 
-        logger.debug("[🔀] Loaded %d server proxies", len(normalised))
+        # Reset time-based assignment when proxy list changes
+        self._current_proxy = None
+        self._current_proxy_since = 0.0
+
+        logger.debug("[🔀] Loaded %d client proxies", len(normalised))
         return len(normalised)
 
     def next(self, *, exclude: Optional[set] = None) -> Optional[str]:
-        """Return the next healthy proxy URL (round-robin), or *None*.
+        """Return the next healthy proxy URL, or *None*.
+
+        Default behaviour (``rotation_interval == 0``): pick one proxy and
+        stick with it indefinitely — only switch when it is suspended.
+
+        When ``rotation_interval > 0``: use one proxy for the configured
+        duration, then advance to the next healthy proxy.
 
         Parameters
         ----------
         exclude:
             Set of proxy URLs to skip (e.g. already tried this request).
+            When provided, a temporary fallback is returned *without*
+            changing the sticky ``_current_proxy`` assignment.
         """
         if not self._proxies:
             return None
@@ -165,6 +215,89 @@ class ProxyRotator:
         exclude = exclude or set()
         now = time.monotonic()
 
+        # Check if the current proxy is still usable
+        if (
+            self._current_proxy
+            and self._current_proxy not in exclude
+            and not self._is_suspended(self._current_proxy, now)
+        ):
+            # With timed rotation, check if the interval has expired
+            if self._rotation_interval > 0:
+                if (now - self._current_proxy_since) < self._rotation_interval:
+                    return self._current_proxy
+                # Interval expired — fall through to assign a new one
+            else:
+                # No rotation — stick with this proxy forever
+                return self._current_proxy
+
+        # ── Retry / fallback (exclude is non-empty) ──
+        # Return a temporary alternative without changing the sticky proxy.
+        if exclude:
+            return self._next_healthy(exclude, now)
+
+        # ── Genuine rotation or first assignment ──
+        proxy = self._next_healthy(exclude, now)
+        if proxy:
+            old = self._current_proxy
+            self._current_proxy = proxy
+            self._current_proxy_since = now
+            safe = _mask_proxy_url(proxy)
+            if old is None:
+                logger.info("[🔀] Using proxy %s", safe)
+            elif old != proxy:
+                logger.info("[🔀] Switched to proxy %s", safe)
+        return proxy
+
+    def rotate_now(self) -> Optional[str]:
+        """Force an immediate rotation to the next healthy proxy.
+
+        Returns the new proxy URL, or *None* if no healthy proxy is
+        available.  Used by the background rotation timer.
+        """
+        if not self._proxies or not self._enabled:
+            return None
+
+        now = time.monotonic()
+        exclude = {self._current_proxy} if self._current_proxy else set()
+        proxy = self._next_healthy(exclude, now)
+
+        # If all other proxies are dead, stick with the current one
+        if not proxy:
+            proxy = self._current_proxy
+
+        if proxy and proxy != self._current_proxy:
+            self._current_proxy = proxy
+            self._current_proxy_since = now
+            logger.info("[🔀] Switched to proxy %s", _mask_proxy_url(proxy))
+        elif proxy and self._current_proxy is None:
+            self._current_proxy = proxy
+            self._current_proxy_since = now
+
+        return proxy
+
+    async def run_rotation_loop(self) -> None:
+        """Background task that rotates the proxy on the configured interval.
+
+        Runs forever; safe to wrap in ``asyncio.create_task``.
+        Sleeps for ``rotation_interval`` seconds, then calls
+        ``rotate_now()``.  Automatically adapts if the interval changes
+        or rotation is disabled.
+        """
+        while True:
+            interval = self._rotation_interval
+            if interval <= 0 or not self._enabled:
+                # No timed rotation — check again in 5s in case settings change
+                await asyncio.sleep(5)
+                continue
+
+            await asyncio.sleep(interval)
+
+            # Re-check after sleep — settings may have changed
+            if self._rotation_interval > 0 and self._enabled:
+                self.rotate_now()
+
+    def _next_healthy(self, exclude: set, now: float) -> Optional[str]:
+        """Advance the round-robin cycle and return the next healthy proxy."""
         for _ in range(len(self._proxies)):
             try:
                 url = next(self._cycle)
@@ -211,11 +344,16 @@ class ProxyRotator:
                 info["failures"],
             )
 
+            # If the suspended proxy was the current time-based proxy, force rotation
+            if self._current_proxy == proxy_url:
+                self._current_proxy = None
+                self._current_proxy_since = 0.0
+
             if self._enabled and self.healthy_count == 0:
                 self._enabled = False
                 logger.warning(
                     "[🔀] All %d proxies dead — proxy rotation auto-disabled, "
-                    "falling back to direct for remainder of sync",
+                    "falling back to direct connection",
                     len(self._proxies),
                 )
                 if self.on_all_dead:

--- a/code/client/proxy_rotator.py
+++ b/code/client/proxy_rotator.py
@@ -19,13 +19,6 @@ import time
 from pathlib import Path
 from typing import List, Optional, Dict
 
-import aiohttp
-
-try:
-    from aiohttp_socks import ProxyConnector
-except ImportError:
-    ProxyConnector = None
-
 logger = logging.getLogger("client.proxy_rotator")
 
 DATA_DIR = Path(os.getenv("DATA_DIR", "/data"))
@@ -106,6 +99,7 @@ class ProxyRotator:
         self._current_proxy_since: float = 0.0
 
         self.on_all_dead: Optional[callable] = None
+        self.on_rotate: Optional[callable] = None
 
     @property
     def enabled(self) -> bool:
@@ -269,6 +263,11 @@ class ProxyRotator:
             self._current_proxy = proxy
             self._current_proxy_since = now
             logger.info("[🔀] Switched to proxy %s", _mask_proxy_url(proxy))
+            if self.on_rotate:
+                try:
+                    self.on_rotate(proxy)
+                except Exception:
+                    pass
         elif proxy and self._current_proxy is None:
             self._current_proxy = proxy
             self._current_proxy_since = now
@@ -387,12 +386,6 @@ class ProxyRotator:
             return []
 
 
-def _is_socks(url: str) -> bool:
-    return url.lower().startswith(
-        ("socks4://", "socks5://", "socks4a://", "socks5h://")
-    )
-
-
 def _mask_proxy_url(url: str) -> str:
     """Mask credentials in a proxy URL for safe logging."""
 
@@ -406,131 +399,3 @@ def _mask_proxy_url(url: str) -> str:
     except Exception:
         pass
     return url[:40] + "…" if len(url) > 40 else url
-
-
-_PROXY_ERRORS = (
-    aiohttp.ClientProxyConnectionError,
-    aiohttp.ClientHttpProxyError,
-    aiohttp.ClientConnectorError,
-    aiohttp.ClientOSError,
-    ConnectionRefusedError,
-    ConnectionResetError,
-    OSError,
-)
-
-
-def _make_connector_for_proxy(proxy_url: str) -> Optional[aiohttp.BaseConnector]:
-    """
-    Build a connector suitable for *proxy_url*.
-    - SOCKS proxies require ``aiohttp_socks.ProxyConnector``.
-    - HTTP proxies just use the ``proxy=`` parameter on each request.
-    """
-    if _is_socks(proxy_url):
-        if ProxyConnector is None:
-            logger.error(
-                "[⛔] aiohttp_socks is required for SOCKS proxies but not installed"
-            )
-            return None
-        return ProxyConnector.from_url(proxy_url)
-    return None  # HTTP proxy – use aiohttp's native proxy= kwarg
-
-
-_MAX_PROXY_RETRIES = 3
-
-
-def patch_discord_http(bot, rotator: ProxyRotator) -> None:
-    """
-    Monkey-patch the py-cord ``HTTPClient.request`` so every outgoing call
-    goes through the next proxy in the rotation (when enabled).
-
-    If a proxy connection fails, automatically retries with the next proxy
-    up to ``_MAX_PROXY_RETRIES`` times.  If all proxied attempts fail,
-    falls back to a direct (no-proxy) request.
-
-    Safe to call multiple times – only patches once.
-    """
-    http_client = bot.http
-
-    # Idempotency guard: don't double-patch on reconnects
-    if getattr(http_client, "_proxy_patched", False):
-        logger.debug("[🔀] Discord HTTP client already patched, skipping")
-        return
-
-    original_request = http_client.request
-
-    async def _do_socks_request(proxy_url, route, **kwargs):
-        """Execute a single request through a SOCKS proxy."""
-        connector = ProxyConnector.from_url(proxy_url)
-        old_session = http_client._HTTPClient__session
-        if old_session and not old_session.closed:
-            new_session = aiohttp.ClientSession(
-                connector=connector,
-                headers=old_session._default_headers,
-            )
-            http_client._HTTPClient__session = new_session
-            try:
-                return await original_request(route, **kwargs)
-            finally:
-                http_client._HTTPClient__session = old_session
-                await new_session.close()
-
-        return await original_request(route, **kwargs)
-
-    async def _proxy_request(route, **kwargs):
-        if not rotator.enabled:
-            return await original_request(route, **kwargs)
-
-        tried: set = set()
-        last_exc = None
-        max_attempts = min(_MAX_PROXY_RETRIES, rotator.count)
-
-        for attempt in range(max_attempts):
-            proxy_url = rotator.next(exclude=tried)
-            if not proxy_url:
-
-                break
-
-            tried.add(proxy_url)
-
-            try:
-                if _is_socks(proxy_url):
-                    if ProxyConnector is not None:
-                        result = await _do_socks_request(proxy_url, route, **kwargs)
-                        rotator.report_success(proxy_url)
-                        return result
-                else:
-                    kwargs["proxy"] = proxy_url
-                    result = await original_request(route, **kwargs)
-                    rotator.report_success(proxy_url)
-                    return result
-
-            except _PROXY_ERRORS as exc:
-                last_exc = exc
-                safe = _mask_proxy_url(proxy_url)
-                logger.debug(
-                    "[🔀] Proxy %s failed (attempt %d/%d): %s",
-                    safe,
-                    attempt + 1,
-                    max_attempts,
-                    type(exc).__name__,
-                )
-                rotator.report_failure(proxy_url)
-
-                if not rotator.enabled:
-                    break
-
-                kwargs.pop("proxy", None)
-                continue
-
-        if last_exc is not None and rotator._enabled:
-            logger.debug(
-                "[🔀] %d proxy attempt(s) failed, falling back to direct connection",
-                len(tried),
-            )
-        kwargs.pop("proxy", None)
-
-        return await original_request(route, **kwargs)
-
-    http_client.request = _proxy_request
-    http_client._proxy_patched = True
-    logger.debug("[🔀] Patched discord HTTP client for proxy rotation")

--- a/code/client/proxy_rotator.py
+++ b/code/client/proxy_rotator.py
@@ -10,9 +10,9 @@
 
 from __future__ import annotations
 
-import itertools
 import logging
 import os
+import random
 import re
 import asyncio
 import time
@@ -86,10 +86,8 @@ class ProxyRotator:
 
     def __init__(self) -> None:
         self._proxies: List[str] = []
-        self._cycle = itertools.cycle([])
         self._lock = asyncio.Lock()
         self._enabled: bool = False
-        self._index: int = 0
 
         self._health: Dict[str, Dict] = {}
 
@@ -175,8 +173,6 @@ class ProxyRotator:
                 normalised.append(url)
 
         self._proxies = normalised
-        self._cycle = itertools.cycle(normalised) if normalised else itertools.cycle([])
-        self._index = 0
 
         self._health = {k: v for k, v in self._health.items() if k in normalised}
 
@@ -275,41 +271,33 @@ class ProxyRotator:
         return proxy
 
     async def run_rotation_loop(self) -> None:
-        """Background task that rotates the proxy on the configured interval.
+        """Background task that handles timed proxy rotation.
 
         Runs forever; safe to wrap in ``asyncio.create_task``.
-        Sleeps for ``rotation_interval`` seconds, then calls
-        ``rotate_now()``.  Automatically adapts if the interval changes
-        or rotation is disabled.
+        Health monitoring is handled reactively via ``on_disconnect``
+        / ``on_resumed`` events in the client — no polling needed.
         """
         while True:
-            interval = self._rotation_interval
-            if interval <= 0 or not self._enabled:
-                # No timed rotation — check again in 5s in case settings change
+            if not self._enabled or self._rotation_interval <= 0:
                 await asyncio.sleep(5)
                 continue
 
-            await asyncio.sleep(interval)
+            if self._current_proxy:
+                elapsed = time.monotonic() - self._current_proxy_since
+                if elapsed >= self._rotation_interval:
+                    self.rotate_now()
 
-            # Re-check after sleep — settings may have changed
-            if self._rotation_interval > 0 and self._enabled:
-                self.rotate_now()
+            await asyncio.sleep(5)
 
     def _next_healthy(self, exclude: set, now: float) -> Optional[str]:
-        """Advance the round-robin cycle and return the next healthy proxy."""
-        for _ in range(len(self._proxies)):
-            try:
-                url = next(self._cycle)
-                self._index = (self._index + 1) % len(self._proxies)
-            except StopIteration:
-                return None
-
-            if url in exclude:
-                continue
-            if not self._is_suspended(url, now):
-                return url
-
-        return None
+        """Pick a random healthy proxy that isn't excluded or suspended."""
+        candidates = [
+            url for url in self._proxies
+            if url not in exclude and not self._is_suspended(url, now)
+        ]
+        if not candidates:
+            return None
+        return random.choice(candidates)
 
     def report_success(self, proxy_url: str) -> None:
         """Mark a proxy as healthy after a successful request."""
@@ -349,10 +337,8 @@ class ProxyRotator:
                 self._current_proxy_since = 0.0
 
             if self._enabled and self.healthy_count == 0:
-                self._enabled = False
                 logger.warning(
-                    "[🔀] All %d proxies dead — proxy rotation auto-disabled, "
-                    "falling back to direct connection",
+                    "[🔀] All %d proxies dead — no healthy proxies available",
                     len(self._proxies),
                 )
                 if self.on_all_dead:

--- a/code/common/config.py
+++ b/code/common/config.py
@@ -15,7 +15,7 @@ from typing import Optional
 from common.db import DBManager
 
 logger = logging.getLogger(__name__)
-CURRENT_VERSION = "v3.20.2"
+CURRENT_VERSION = "v3.21.0"
 
 
 class Config:

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -42,7 +42,6 @@ from common.common_helpers import resolve_mapping_settings
 from common.websockets import WebsocketManager, AdminBus
 from common.db import DBManager
 from server.rate_limiter import RateLimitManager, ActionType
-from server.proxy_rotator import ProxyRotator, patch_discord_http
 from server.emojis import EmojiManager
 from server.stickers import StickerManager
 from server.roles import RoleManager
@@ -270,9 +269,6 @@ class ServerReceiver:
         )
         self.onjoin = OnJoinService(self.bot, self.db, logger.getChild("OnJoin"))
 
-        self.proxy_rotator = ProxyRotator()
-        self._init_proxy_rotator()
-
         self.MAX_GUILD_CHANNELS = 500
         self.MAX_CATEGORIES = 50
         self.MAX_CHANNELS_PER_CATEGORY = 50
@@ -288,20 +284,6 @@ class ServerReceiver:
 
         self.bot.on_connect = _command_sync
         self.bot.load_extension("server.commands")
-
-    def _init_proxy_rotator(self) -> None:
-        """Load proxy list and check the ENABLE_SERVER_PROXIES db flag.
-
-        Proxies are loaded but kept **disabled** — they are only activated
-        for the duration of a ``sync_structure`` call so that login,
-        slash-command sync, message forwarding, etc. always go direct.
-        """
-        self.proxy_rotator.reload()
-        self._proxy_wanted = (
-            self.db.get_config("ENABLE_SERVER_PROXIES", "") or ""
-        ).strip().lower() in ("1", "true", "yes")
-
-        self.proxy_rotator.set_enabled(False)
 
     def _target_clone_gid_for_origin(self, host_guild_id: int | None) -> int | None:
         return self.guild_resolver.resolve_target_clone(host_guild_id=host_guild_id)
@@ -838,9 +820,6 @@ class ServerReceiver:
         asyncio.create_task(self.config.setup_release_watcher(self))
         self.session = aiohttp.ClientSession()
         self.webhook_exporter = WebhookDMExporter(self.session, logger)
-
-        self._init_proxy_rotator()
-        patch_discord_http(self.bot, self.proxy_rotator)
 
         mapped = set(self.db.get_all_clone_guild_ids())
         present = (
@@ -1824,14 +1803,6 @@ class ServerReceiver:
         Synchronizes the structure of a clone based on the provided sitemap.
         """
 
-        self._init_proxy_rotator()
-        if self._proxy_wanted and self.proxy_rotator.count:
-            self.proxy_rotator.set_enabled(True)
-            self.ratelimit.set_proxy_bypass(True)
-            self.proxy_rotator.on_all_dead = (
-                lambda _rot: self.ratelimit.set_proxy_bypass(False)
-            )
-
         logger.debug(f"Sync Task #{task_id}: Processing sitemap {sitemap}")
 
         host_guild_id_raw = (sitemap.get("guild") or {}).get("id")
@@ -2032,8 +2003,6 @@ class ServerReceiver:
                 return "; ".join(summaries) if summaries else "No changes needed"
 
         finally:
-            self.proxy_rotator.set_enabled(False)
-            self.ratelimit.set_proxy_bypass(False)
             logctx.sync_host_name.reset(_host_token)
             logctx.sync_display_id.reset(_id_token)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   admin:
-    image: ghcr.io/copycord/copycord:v3.20.2
+    image: ghcr.io/copycord/copycord:v3.21.0
     container_name: copycord-admin
     environment:
       - ROLE=admin
@@ -11,7 +11,7 @@ services:
       - ./data:/data
 
   server:
-    image: ghcr.io/copycord/copycord:v3.20.2
+    image: ghcr.io/copycord/copycord:v3.21.0
     container_name: copycord-server
     environment:
       - ROLE=server
@@ -21,7 +21,7 @@ services:
       - admin
 
   client:
-    image: ghcr.io/copycord/copycord:v3.20.2
+    image: ghcr.io/copycord/copycord:v3.21.0
     container_name: copycord-client
     environment:
       - ROLE=client

--- a/website/docs/configuration/advanced.md
+++ b/website/docs/configuration/advanced.md
@@ -27,19 +27,53 @@ Edit `ADMIN_PORT` in `code/.env`:
 ADMIN_PORT=9060
 ```
 
-## Proxy support for scraping
+## Proxy support
 
-Copycord supports proxy rotation for the member scraper and server bot operations. Configure proxies through the dashboard:
+Copycord routes all client (self bot) traffic through a proxy when enabled — including login, REST API calls, and the gateway WebSocket connection. This means your real IP never touches Discord.
 
-1. Go to the **Scraper** page → Proxy settings
-2. Add proxy URLs (one per line), e.g.:
+### Configuring client proxies
+
+1. Go to the **Configuration** page → **Proxy** card
+2. Enable **"Enable proxies for client"**
+3. Paste one or more proxies — supported formats:
    ```
+   host:port
+   host:port:user:pass
+   user:pass@host:port
    http://user:pass@proxy1.example.com:8080
    socks5://user:pass@proxy2.example.com:1080
    ```
-3. Save
+4. Proxies auto-save as you add or remove them
 
 Both HTTP and SOCKS5 proxies are supported.
+
+### Proxy rotation
+
+By default, one proxy is selected and used for all traffic. It only switches if the proxy fails.
+
+To rotate proxies on a schedule, enable **"Rotate every"** and set an interval (e.g. 1 hour). The client will automatically switch to the next healthy proxy after the set duration.
+
+:::tip
+Longer rotation intervals (1-4 hours) are recommended. Rotating too frequently can itself be a detection signal. Residential proxies are strongly preferred over datacenter IPs.
+:::
+
+### Testing proxies
+
+Click **Test All** to verify your proxies. Each proxy is tested by connecting to Discord's API through it. Results show which proxies are healthy, slow (>3s), or failed. You can remove failed and slow proxies directly from the results.
+
+For large proxy lists, the test runs as a background task with a live progress bar. You can stop it at any time.
+
+The test batch size defaults to 50 concurrent and can be configured via environment variable:
+
+```yaml
+admin:
+  environment:
+    PROXY_TEST_BATCH_SIZE: 100
+```
+
+### Scraper proxies
+
+The member scraper shares the same proxy list. When proxies are configured, the scraper automatically uses them to distribute requests across different IPs.
 
 ## Message retention
 
@@ -110,4 +144,4 @@ Copycord relies on discord.py's native rate limit handling for structure sync op
 
 For webhook message sending, Copycord uses a lightweight rate limiter (5 per 2.5s per webhook) to stay within Discord's message rate limits.
 
-If you're using proxies, requests are distributed across different IPs, allowing higher throughput.
+If you're using proxies for the client, traffic is routed through the proxy IP, keeping your real IP hidden from Discord.

--- a/website/docs/configuration/advanced.md
+++ b/website/docs/configuration/advanced.md
@@ -59,17 +59,27 @@ Longer rotation intervals (1-4 hours) are recommended. Rotating too frequently c
 
 ### Testing proxies
 
-Click **Test All** to verify your proxies. Each proxy is tested by connecting to Discord's API through it. Results show which proxies are healthy, slow (>3s), or failed. You can remove failed and slow proxies directly from the results.
+Click **Test All** to verify your proxies. Each proxy is tested by connecting to Discord's API through it. Results show which proxies are healthy, slow, or failed. You can remove failed and slow proxies directly from the results.
 
 For large proxy lists, the test runs as a background task with a live progress bar. You can stop it at any time.
 
-The test batch size defaults to 50 concurrent and can be configured via environment variable:
+### Failover
 
-```yaml
-admin:
-  environment:
-    PROXY_TEST_BATCH_SIZE: 100
-```
+If the active proxy drops or goes down, the client detects it automatically via the Discord gateway connection and switches to the next available proxy. No polling or extra API calls are made — detection is fully reactive.
+
+A failed proxy is temporarily suspended so the client doesn't reconnect to it immediately. After the suspend duration expires, the proxy becomes eligible again.
+
+### Proxy settings
+
+Click the **Settings** button on the Proxy card to configure advanced options:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Suspend duration** | 300s | How long a failed proxy stays blocked before retrying |
+| **Batch size** | 50 | Number of proxies tested concurrently during "Test All" |
+| **Slow threshold** | 3s | Proxies slower than this are flagged in test results |
+
+All settings are saved to the database. Suspend duration takes effect on next client restart. Test settings apply immediately.
 
 ### Scraper proxies
 

--- a/website/docs/dashboard/scraper.md
+++ b/website/docs/dashboard/scraper.md
@@ -35,11 +35,7 @@ Each token must belong to an account that is a member of the server you want to 
 
 ### Configure proxies (optional)
 
-For large servers, you can add proxy servers to distribute requests:
-
-1. On the Scraper page, click the proxy settings
-2. Add proxy URLs (one per line)
-3. Save
+For large servers, add proxies to distribute requests. The scraper uses the shared proxy list from the **Proxy** card on the [Configuration](/docs/configuration/advanced#proxy-support) page.
 
 ## Running a scrape
 

--- a/website/docs/features/member-scraping.md
+++ b/website/docs/features/member-scraping.md
@@ -28,10 +28,7 @@ Multiple tokens enable parallel scraping for faster results.
 
 ### 2. Configure proxies (optional)
 
-For large servers or to distribute load, add proxy servers:
-
-- HTTP proxies: `http://user:pass@host:port`
-- SOCKS5 proxies: `socks5://user:pass@host:port`
+For large servers or to distribute load, configure proxies in the **Proxy** card on the [Configuration](/docs/configuration/advanced#proxy-support) page. The scraper shares the same proxy list as the client.
 
 ### 3. Start a scrape
 

--- a/website/docs/getting-started/docker-install.md
+++ b/website/docs/getting-started/docker-install.md
@@ -52,7 +52,7 @@ Create a file named `docker-compose.yml` with the following content:
 ```yaml
 services:
   admin:
-    image: ghcr.io/copycord/copycord:v3.20.2
+    image: ghcr.io/copycord/copycord:v3.21.0
     container_name: copycord-admin
     environment:
       - ROLE=admin
@@ -64,7 +64,7 @@ services:
     restart: unless-stopped
 
   server:
-    image: ghcr.io/copycord/copycord:v3.20.2
+    image: ghcr.io/copycord/copycord:v3.21.0
     container_name: copycord-server
     environment:
       - ROLE=server
@@ -75,7 +75,7 @@ services:
     restart: unless-stopped
 
   client:
-    image: ghcr.io/copycord/copycord:v3.20.2
+    image: ghcr.io/copycord/copycord:v3.21.0
     container_name: copycord-client
     environment:
       - ROLE=client


### PR DESCRIPTION
## Summary
- Proxies now only apply to the client (self bot) — all Discord traffic (login, API, gateway) is routed through the proxy
- Reactive failover — if a proxy drops, the client detects it and switches automatically
- On startup, cycles through proxies until one connects. Never use direct connection when proxy is enabled.
- Timed rotation support (default 1 hour) with random proxy selection
- Redesigned proxy UI, bulk testing with progress bar, and settings modal
- Merged scraper proxy UI into one shared proxy list on the Configuration page
- Removed all proxy logic from the server bot