### PR TITLE
Feature/better sitemaps

### DIFF
--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -4175,6 +4175,7 @@ async def api_server_proxies_test_stop():
 _SYNC_SETTINGS_KEYS = {
     "SYNC_STARTUP_DELAY": 15,
     "SYNC_INTER_GUILD_DELAY": 3,
+    "SYNC_RANDOMIZE_ORDER": 1,
 }
 
 

--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -4172,6 +4172,48 @@ async def api_server_proxies_test_stop():
     return JSONResponse({"ok": False, "error": "No test running"})
 
 
+_SYNC_SETTINGS_KEYS = {
+    "SYNC_STARTUP_DELAY": 15,
+    "SYNC_INTER_GUILD_DELAY": 3,
+}
+
+
+@app.get("/api/sync/settings", response_class=JSONResponse)
+async def api_sync_settings_get():
+    """Return sync timing settings."""
+    try:
+        settings = {}
+        for key, default in _SYNC_SETTINGS_KEYS.items():
+            raw = (db.get_config(key, "") or "").strip()
+            try:
+                settings[key] = int(raw) if raw else default
+            except (ValueError, TypeError):
+                settings[key] = default
+        return JSONResponse({"ok": True, "settings": settings})
+    except Exception as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+
+@app.put("/api/sync/settings", response_class=JSONResponse)
+async def api_sync_settings_put(request: Request):
+    """Save sync timing settings."""
+    try:
+        payload = await request.json()
+    except Exception:
+        raise HTTPException(400, detail="Invalid JSON")
+    settings = payload.get("settings", {})
+    if not isinstance(settings, dict):
+        raise HTTPException(400, detail="settings must be an object")
+    try:
+        for key, default in _SYNC_SETTINGS_KEYS.items():
+            if key in settings:
+                val = max(1, int(settings[key]))
+                db.set_config(key, str(val))
+        return JSONResponse({"ok": True})
+    except Exception as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+
 @app.post("/api/scraper/start", response_class=JSONResponse)
 async def api_scraper_start(request: Request):
     """Start standalone scraper with multiple tokens (single guild, immediate start)."""

--- a/code/admin/frontend/src/js/app.js
+++ b/code/admin/frontend/src/js/app.js
@@ -5566,6 +5566,51 @@
     loadSrvProxies();
     checkProxyTestStatus();
     loadProxySettings();
+
+    // ─── Sync Timing Settings ─────────────────────────────────────────────
+    const syncStartupDelay = document.getElementById("sync-startup-delay");
+    const syncGuildDelay   = document.getElementById("sync-guild-delay");
+    const syncCard         = document.getElementById("sync-settings-card");
+
+    async function loadSyncSettings() {
+      try {
+        const r = await fetch("/api/sync/settings");
+        const j = await r.json();
+        if (j.ok && j.settings) {
+          if (syncStartupDelay) syncStartupDelay.value = j.settings.SYNC_STARTUP_DELAY || 15;
+          if (syncGuildDelay) syncGuildDelay.value = j.settings.SYNC_INTER_GUILD_DELAY || 3;
+        }
+      } catch (e) { console.error("Failed to load sync settings:", e); }
+    }
+
+    let _syncSaveTimer = null;
+    function scheduleSyncSave() {
+      clearTimeout(_syncSaveTimer);
+      _syncSaveTimer = setTimeout(async () => {
+        const settings = {};
+        if (syncStartupDelay) settings.SYNC_STARTUP_DELAY = parseInt(syncStartupDelay.value, 10) || 15;
+        if (syncGuildDelay) settings.SYNC_INTER_GUILD_DELAY = parseInt(syncGuildDelay.value, 10) || 3;
+        try {
+          await fetch("/api/sync/settings", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ settings }),
+          });
+        } catch (e) { console.error(e); }
+      }, 600);
+    }
+
+    if (syncStartupDelay) syncStartupDelay.addEventListener("change", scheduleSyncSave);
+    if (syncGuildDelay) syncGuildDelay.addEventListener("change", scheduleSyncSave);
+
+    if (syncCard) {
+      if (localStorage.getItem("cpc.sync-card-open") === "1") syncCard.open = true;
+      syncCard.addEventListener("toggle", () => {
+        localStorage.setItem("cpc.sync-card-open", syncCard.open ? "1" : "0");
+      });
+    }
+
+    loadSyncSettings();
   });
 
   ["server", "client"].forEach((role) => {

--- a/code/admin/frontend/src/js/app.js
+++ b/code/admin/frontend/src/js/app.js
@@ -723,6 +723,15 @@
         chipsEl.classList.remove("locked-field");
       }
     });
+
+    // Wire auto-start toggle to hidden select
+    const gcAutoToggle = document.getElementById("gc-autostart-toggle");
+    const gcAutoSelect = document.getElementById("COPYCORD_AUTOSTART");
+    if (gcAutoToggle && gcAutoSelect) {
+      gcAutoToggle.addEventListener("change", () => {
+        gcAutoSelect.value = gcAutoToggle.checked ? "true" : "false";
+      });
+    }
   }
 
   function setGuildCardsLocked(running) {
@@ -5570,6 +5579,7 @@
     // ─── Sync Timing Settings ─────────────────────────────────────────────
     const syncStartupDelay = document.getElementById("sync-startup-delay");
     const syncGuildDelay   = document.getElementById("sync-guild-delay");
+    const syncRandomize    = document.getElementById("sync-randomize");
     const syncCard         = document.getElementById("sync-settings-card");
 
     async function loadSyncSettings() {
@@ -5579,6 +5589,7 @@
         if (j.ok && j.settings) {
           if (syncStartupDelay) syncStartupDelay.value = j.settings.SYNC_STARTUP_DELAY || 15;
           if (syncGuildDelay) syncGuildDelay.value = j.settings.SYNC_INTER_GUILD_DELAY || 3;
+          if (syncRandomize) syncRandomize.checked = !!(j.settings.SYNC_RANDOMIZE_ORDER ?? 1);
         }
       } catch (e) { console.error("Failed to load sync settings:", e); }
     }
@@ -5590,6 +5601,7 @@
         const settings = {};
         if (syncStartupDelay) settings.SYNC_STARTUP_DELAY = parseInt(syncStartupDelay.value, 10) || 15;
         if (syncGuildDelay) settings.SYNC_INTER_GUILD_DELAY = parseInt(syncGuildDelay.value, 10) || 3;
+        if (syncRandomize) settings.SYNC_RANDOMIZE_ORDER = syncRandomize.checked ? 1 : 0;
         try {
           await fetch("/api/sync/settings", {
             method: "PUT",
@@ -5602,6 +5614,7 @@
 
     if (syncStartupDelay) syncStartupDelay.addEventListener("change", scheduleSyncSave);
     if (syncGuildDelay) syncGuildDelay.addEventListener("change", scheduleSyncSave);
+    if (syncRandomize) syncRandomize.addEventListener("change", scheduleSyncSave);
 
     if (syncCard) {
       if (localStorage.getItem("cpc.sync-card-open") === "1") syncCard.open = true;

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -10753,6 +10753,115 @@ body.page-forwarding .fwd-no-match-sub {
   background: var(--border, rgba(255, 255, 255, 0.12));
   margin: 0 2px;
 }
+#cfg-form .field-token,
+#cfg-form .field-chips {
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.06));
+  transition: background 0.12s ease;
+}
+#cfg-form .field-token:hover,
+#cfg-form .field-chips:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+.gc-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0;
+}
+.gc-label-row .token-label-btn {
+  position: static;
+  margin: 0;
+}
+.gc-field-hint {
+  display: block;
+  font-size: 11px;
+  color: var(--muted);
+  opacity: 0.7;
+  line-height: 1.4;
+  margin: 0 0 4px;
+}
+.gc-settings-section {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 22px;
+  grid-column: 1 / -1;
+  margin-top: -4px;
+}
+@media (max-width: 900px) {
+  .gc-settings-section {
+    grid-template-columns: 1fr;
+  }
+}
+.gc-setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.06));
+  transition: background 0.12s ease;
+}
+.gc-setting-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+.gc-setting-row > .proxy-settings-label {
+  flex: 1 1 0%;
+  min-width: 0;
+  margin-right: auto;
+}
+.gc-setting-row .proxy-settings-label > span:first-child {
+  font-size: 13px;
+  font-weight: 500;
+}
+.gc-setting-row .proxy-settings-sublabel {
+  font-size: 11px;
+}
+.gc-setting-control {
+  flex-shrink: 0;
+  display: inline-flex !important;
+  align-items: center;
+  margin: 0;
+  margin-left: auto;
+}
+.gc-setting-control.toggle .toggle-track {
+  min-width: 38px;
+}
+.gc-setting-chips {
+  flex-direction: column;
+  align-items: stretch;
+}
+.gc-select {
+  width: 100px;
+  height: 34px;
+  padding: 0 28px 0 12px;
+  font-size: 13px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: #140b26;
+  color: var(--text);
+  outline: 0;
+  cursor: pointer;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%239e95b7' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  transition: border-color 0.15s ease;
+}
+.gc-select:focus {
+  border-color: var(--brand, var(--accent));
+}
+@media (max-width: 900px) {
+  .gc-settings-section {
+    grid-template-columns: 1fr;
+  }
+}
 
 /* ─── Mapping Modal ─── */
 .mapping-form {
@@ -11147,7 +11256,6 @@ body.page-forwarding .fwd-no-match-sub {
   gap: 10px;
   cursor: pointer;
   list-style: none;
-  user-select: none;
   padding: 0;
 }
 .srv-proxy-summary::-webkit-details-marker {
@@ -11181,6 +11289,8 @@ body.page-forwarding .fwd-no-match-sub {
 .srv-proxy-summary h3 {
   margin: 0;
   font-size: 15px;
+  user-select: text;
+  cursor: text;
 }
 .srv-proxy-chip {
   font-size: 11px;
@@ -11309,7 +11419,6 @@ body.page-forwarding .fwd-no-match-sub {
 .proxy-settings-unit {
   font-size: 11px;
   color: var(--muted);
-  min-width: 48px;
 }
 .proxy-settings-footer-row {
   display: flex;

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -11153,21 +11153,36 @@ body.page-forwarding .fwd-no-match-sub {
 .srv-proxy-summary::-webkit-details-marker {
   display: none;
 }
-.srv-proxy-summary::before {
-  content: '▸';
+.srv-proxy-summary .card-chev {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  width: 28px;
+  padding: 0;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  color: var(--accent);
   font-size: 13px;
-  color: var(--muted);
-  transition: transform 0.15s ease;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+  transform: rotate(-90deg);
+  flex-shrink: 0;
+  order: 99;
+  margin-left: auto;
 }
-.srv-proxy-card[open] .srv-proxy-summary::before {
-  transform: rotate(90deg);
+.srv-proxy-summary:hover .card-chev {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(167, 139, 250, 0.3);
+}
+.srv-proxy-card[open] .srv-proxy-summary .card-chev {
+  transform: rotate(0deg);
 }
 .srv-proxy-summary h3 {
   margin: 0;
   font-size: 15px;
 }
 .srv-proxy-chip {
-  margin-left: auto;
   font-size: 11px;
   font-weight: 600;
   line-height: 1;

--- a/code/admin/templates/index.html
+++ b/code/admin/templates/index.html
@@ -449,6 +449,41 @@
       <div id="guild-mapping-list" class="guild-mapping-list"></div>
     </div>
 
+    <!-- ─── Sync Settings ─── -->
+    <details class="card srv-proxy-card" id="sync-settings-card">
+      <summary class="srv-proxy-summary">
+        <h3>Sync Settings</h3>
+        <span class="card-chev" aria-hidden="true">&#9662;</span>
+      </summary>
+      <div class="srv-proxy-body">
+        <p class="srv-proxy-hint">
+          When the client starts, it scans each server you're cloning and sends the full structure (channels, roles, emojis) to the bot so it knows what to sync. These settings control how fast that happens. Slower is always safer if you have many servers. Changes apply on next client restart.
+        </p>
+        <div class="proxy-settings-fields" style="margin-top:10px">
+          <label class="proxy-settings-field">
+            <div class="proxy-settings-label">
+              <span>Startup Delay</span>
+              <span class="proxy-settings-sublabel">Wait time after login before sending sitemaps</span>
+            </div>
+            <div class="proxy-settings-input-wrap">
+              <input type="number" id="sync-startup-delay" class="input ps-input" min="1" max="120" value="15" />
+              <span class="proxy-settings-unit">sec</span>
+            </div>
+          </label>
+          <label class="proxy-settings-field">
+            <div class="proxy-settings-label">
+              <span>Inter-Guild Delay</span>
+              <span class="proxy-settings-sublabel">Pause between each server sitemap to help avoid rate limits.</span>
+            </div>
+            <div class="proxy-settings-input-wrap">
+              <input type="number" id="sync-guild-delay" class="input ps-input" min="1" max="30" value="3" />
+              <span class="proxy-settings-unit">sec</span>
+            </div>
+          </label>
+        </div>
+      </div>
+    </details>
+
     <!-- ─── Proxy ─── -->
     <details class="card srv-proxy-card" id="srv-proxy-card">
       <summary class="srv-proxy-summary">
@@ -462,6 +497,7 @@
           </svg>
           Settings
         </button>
+        <span class="card-chev" aria-hidden="true">&#9662;</span>
       </summary>
       <div class="srv-proxy-body">
         <div class="srv-proxy-toggle-row">

--- a/code/admin/templates/index.html
+++ b/code/admin/templates/index.html
@@ -241,8 +241,8 @@
 
     {# Shared tips dictionary for global + mapping modal #}
     {% set FIELD_TIPS = {
-    "SERVER_TOKEN": "Your Discord bot token from the Developer Portal.",
-    "CLIENT_TOKEN": "Your Discord account token, visit repo for instructions on how to obtain.",
+    "SERVER_TOKEN": "Your bot token from the Discord Developer Portal. Only needs to be invited to your clone servers.",
+    "CLIENT_TOKEN": "Your Discord account token from the console. Must be in any of the servers you want to clone.",
     "COMMAND_USERS": "Comma-separated Discord user IDs allowed to run slash commands.",
     "LOG_LEVEL": "INFO for normal use, DEBUG for troubleshooting.",
     "HOST_GUILD_ID": "ID of the host server to mirror. Your account bot must be a member of this server.",
@@ -295,24 +295,21 @@
 
       <form method="post" action="/save" id="cfg-form" novalidate>
         <div class="grid">
+          {% set GC_NAMES = {
+            "SERVER_TOKEN": "Server Token",
+            "CLIENT_TOKEN": "Client Token",
+            "COMMAND_USERS": "Command Users",
+          } %}
           {% for k in text_keys if k != 'COMMAND_USERS' %}
           {% set is_token = 'TOKEN' in k %}
           <div class="field field-token">
-            <label for="{{ k }}" class="has-tip{% if k == 'CLIENT_TOKEN' %} token-label{% endif %}">
-              {% if k == 'CLIENT_TOKEN' %}
-              <span class="label-left">
-                <span class="label-text">{{ k }}</span>
-                {% if FIELD_TIPS.get(k) %}
-                <button type="button" class="info-dot" aria-label="What is {{ k }}?"
-                  aria-describedby="tip-{{ k }}"></button>
-                <span id="tip-{{ k }}" role="tooltip" class="tip-bubble">
-                  {{ FIELD_TIPS[k] }}
-                </span>
-                {% endif %}
-              </span>
-
+            {% if k == 'CLIENT_TOKEN' %}
+            <div class="gc-label-row">
+              <label for="{{ k }}">
+                <span class="label-text">{{ GC_NAMES.get(k, k) }}</span>
+              </label>
               <button type="button" class="token-label-btn" id="backupTokensBtn"
-                aria-label="Manage backup CLIENT_TOKENs" title="Manage backup CLIENT_TOKENs">
+                aria-label="Manage backup CLIENT_TOKENs" title="Manage backup tokens">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor"
                   stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"
                   aria-hidden="true">
@@ -320,17 +317,15 @@
                   <circle cx="12" cy="7" r="4" />
                 </svg>
               </button>
-              {% else %}
-              <span class="label-text">{{ k }}</span>
-              {% if FIELD_TIPS.get(k) %}
-              <button type="button" class="info-dot" aria-label="What is {{ k }}?"
-                aria-describedby="tip-{{ k }}"></button>
-              <span id="tip-{{ k }}" role="tooltip" class="tip-bubble">
-                {{ FIELD_TIPS[k] }}
-              </span>
-              {% endif %}
-              {% endif %}
+            </div>
+            {% else %}
+            <label for="{{ k }}">
+              <span class="label-text">{{ GC_NAMES.get(k, k) }}</span>
             </label>
+            {% endif %}
+            {% if FIELD_TIPS.get(k) %}
+            <span class="gc-field-hint">{{ FIELD_TIPS[k] }}</span>
+            {% endif %}
 
             {% if is_token %}
             <div class="token-wrap">
@@ -359,69 +354,59 @@
           </div>
           {% endfor %}
 
-          <div class="field field-chips">
-            <label for="cmd_users_input" class="has-tip">
-              <span class="label-text">COMMAND_USERS</span>
-              {% if FIELD_TIPS.get('COMMAND_USERS') %}
-              <button type="button" class="info-dot" aria-label="What is COMMAND_USERS?"
-                aria-describedby="tip-COMMAND_USERS"></button>
-              <span id="tip-COMMAND_USERS" role="tooltip" class="tip-bubble">
-                {{ FIELD_TIPS['COMMAND_USERS'] }}
-              </span>
-              {% endif %}
-            </label>
-
-            <div class="chips chips-compact" data-chips="cmd_users">
-              <input id="cmd_users_input" class="chip-input" type="text" inputmode="numeric" />
+          <div class="gc-settings-section">
+            <div class="gc-setting-row gc-setting-chips">
+              <div>
+                <div class="proxy-settings-label">
+                  <span>Command Users</span>
+                  <span class="proxy-settings-sublabel">{{ FIELD_TIPS['COMMAND_USERS'] }}</span>
+                </div>
+                <div class="chips chips-compact" data-chips="cmd_users" style="margin-top:6px">
+                  <input id="cmd_users_input" class="chip-input" type="text" inputmode="numeric" />
+                </div>
+                <input type="hidden" name="COMMAND_USERS" id="COMMAND_USERS" value="{{ env.get('COMMAND_USERS','') }}">
+              </div>
             </div>
-            <input type="hidden" name="COMMAND_USERS" id="COMMAND_USERS" value="{{ env.get('COMMAND_USERS','') }}">
-          </div>
 
-          <div class="field">
-            <label for="LOG_LEVEL" class="has-tip">
-              <span class="label-text">LOG_LEVEL</span>
-              <button type="button" class="info-dot" aria-label="What is LOG_LEVEL?"
-                aria-describedby="tip-LOG_LEVEL"></button>
-              <span id="tip-LOG_LEVEL" role="tooltip" class="tip-bubble">
-                {{ FIELD_TIPS['LOG_LEVEL'] }}
-              </span>
-            </label>
-            <div class="select">
-              <select id="LOG_LEVEL" name="LOG_LEVEL">
+            <div class="gc-setting-row">
+              <div class="proxy-settings-label">
+                <span>Auto Start</span>
+                <span class="proxy-settings-sublabel">{{ FIELD_TIPS['COPYCORD_AUTOSTART'] }}</span>
+              </div>
+              <label class="toggle gc-setting-control">
+                <input type="checkbox" id="gc-autostart-toggle"
+                  {{ 'checked' if (env.get('COPYCORD_AUTOSTART','false')|lower)=='true' else '' }} />
+                <span class="toggle-track"><span class="toggle-thumb"></span></span>
+              </label>
+              <select id="COPYCORD_AUTOSTART" name="COPYCORD_AUTOSTART" data-dd style="display:none">
+                <option value="false" {{ 'selected' if (env.get('COPYCORD_AUTOSTART','false')|lower)=='false' else '' }}>false</option>
+                <option value="true" {{ 'selected' if (env.get('COPYCORD_AUTOSTART','false')|lower)=='true' else '' }}>true</option>
+              </select>
+            </div>
+
+            <div class="gc-setting-row">
+              <div class="proxy-settings-label">
+                <span>Log Level</span>
+                <span class="proxy-settings-sublabel">{{ FIELD_TIPS['LOG_LEVEL'] }}</span>
+              </div>
+              <select id="LOG_LEVEL" name="LOG_LEVEL" data-dd class="gc-select gc-setting-control">
                 <option value="INFO" {{ 'selected' if (log_level|upper)=='INFO' else '' }}>INFO</option>
                 <option value="DEBUG" {{ 'selected' if (log_level|upper)=='DEBUG' else '' }}>DEBUG</option>
               </select>
             </div>
-          </div>
 
-          <div class="field">
-            <label for="COPYCORD_AUTOSTART" class="has-tip">
-              <span class="label-text">AUTO_START</span>
-              <button type="button" class="info-dot" aria-label="What is AUTO_START?"
-                aria-describedby="tip-COPYCORD_AUTOSTART"></button>
-              <span id="tip-COPYCORD_AUTOSTART" role="tooltip" class="tip-bubble">
-                {{ FIELD_TIPS['COPYCORD_AUTOSTART'] }}
-              </span>
-            </label>
-            <div class="select">
-              <select id="COPYCORD_AUTOSTART" name="COPYCORD_AUTOSTART">
-                <option value="false" {{ 'selected' if (env.get('COPYCORD_AUTOSTART','false')|lower)=='false' else '' }}>False</option>
-                <option value="true" {{ 'selected' if (env.get('COPYCORD_AUTOSTART','false')|lower)=='true' else '' }}>True</option>
-              </select>
+            <div class="gc-setting-row">
+              <div class="proxy-settings-label">
+                <span>Max Log Size</span>
+                <span class="proxy-settings-sublabel">{{ FIELD_TIPS['LOG_MAX_SIZE_MB'] }}</span>
+              </div>
+              <div class="proxy-settings-input-wrap gc-setting-control">
+                <input type="number" id="LOG_MAX_SIZE_MB" name="LOG_MAX_SIZE_MB"
+                  value="{{ env.get('LOG_MAX_SIZE_MB','10') }}" min="0" step="1"
+                  class="ps-input" />
+                <span class="proxy-settings-unit">MB</span>
+              </div>
             </div>
-          </div>
-
-          <div class="field">
-            <label for="LOG_MAX_SIZE_MB" class="has-tip">
-              <span class="label-text">MAX_LOG_SIZE_MB</span>
-              <button type="button" class="info-dot" aria-label="What is MAX_LOG_SIZE_MB?"
-                aria-describedby="tip-LOG_MAX_SIZE_MB"></button>
-              <span id="tip-LOG_MAX_SIZE_MB" role="tooltip" class="tip-bubble">
-                {{ FIELD_TIPS['LOG_MAX_SIZE_MB'] }}
-              </span>
-            </label>
-            <input type="number" id="LOG_MAX_SIZE_MB" name="LOG_MAX_SIZE_MB"
-              value="{{ env.get('LOG_MAX_SIZE_MB','10') }}" min="0" step="1" />
           </div>
 
           <div class="btns">
@@ -480,6 +465,16 @@
               <span class="proxy-settings-unit">sec</span>
             </div>
           </label>
+          <div class="proxy-settings-field">
+            <div class="proxy-settings-label">
+              <span>Randomize Order</span>
+              <span class="proxy-settings-sublabel">Process servers in random order each startup to avoid predictable patterns</span>
+            </div>
+            <label class="toggle" style="flex-shrink:0;margin:0">
+              <input type="checkbox" id="sync-randomize" checked />
+              <span class="toggle-track"><span class="toggle-thumb"></span></span>
+            </label>
+          </div>
         </div>
       </div>
     </details>

--- a/code/client/client.py
+++ b/code/client/client.py
@@ -152,6 +152,15 @@ class ClientListener:
         self.sitemap = SitemapService(
             bot=self.bot, config=self.config, db=self.db, ws=self.ws, logger=logger
         )
+        # Load configurable sync timing from DB
+        def _db_int_sync(key, default):
+            raw = (self.db.get_config(key, "") or "").strip()
+            try:
+                return int(raw) if raw else default
+            except (ValueError, TypeError):
+                return default
+        self.sitemap._startup_delay = _db_int_sync("SYNC_STARTUP_DELAY", 15)
+        self.sitemap._inter_guild_delay = _db_int_sync("SYNC_INTER_GUILD_DELAY", 3)
         self.ui_controller = ClientUiController(
             bus=self.bus,
             admin_base_url=self.config.ADMIN_WS_URL,
@@ -891,15 +900,37 @@ class ClientListener:
 
         return channel, channel_id, guild
 
-    async def periodic_sync_loop(self):
+    async def _startup_sync(self):
+        """One-time sitemap sync on startup. Events handle changes after this."""
         await self.bot.wait_until_ready()
-        await asyncio.sleep(5)
-        while True:
+
+        startup_delay = self.sitemap._startup_delay
+        logger.info(
+            "[sitemap] Waiting %ds before startup sync", startup_delay
+        )
+        await asyncio.sleep(startup_delay)
+
+        stress_test = os.getenv("SITEMAP_STRESS_TEST", "").lower() in ("1", "true", "yes")
+
+        if stress_test:
+            cycle = 0
+            logger.warning("[sitemap] STRESS TEST enabled — will loop sitemaps continuously")
+            while True:
+                cycle += 1
+                logger.info("[sitemap] Stress test cycle %d", cycle)
+                try:
+                    await self.sitemap.build_and_send_all()
+                except Exception:
+                    logger.exception("[sitemap] Stress test cycle %d failed", cycle)
+                # Wait for the queue to finish before starting next cycle
+                while self.sitemap._queue:
+                    await asyncio.sleep(1)
+                await asyncio.sleep(2)
+        else:
             try:
                 await self.sitemap.build_and_send_all()
             except Exception:
-                logger.exception("Error in periodic sync loop")
-            await asyncio.sleep(self.config.SYNC_INTERVAL_SECONDS)
+                logger.exception("Error in startup sitemap sync")
 
     def schedule_sync(self, guild_id: int | None = None, delay: float = 1.0):
         """
@@ -958,8 +989,8 @@ class ClientListener:
         )
         logger.info("[🤖] %s", msg)
 
-        if self._sync_task is None:
-            self._sync_task = asyncio.create_task(self.periodic_sync_loop())
+        if self._sync_task is None or self._sync_task.done():
+            self._sync_task = asyncio.create_task(self._startup_sync())
 
         if self._ws_task is None:
             self._ws_task = asyncio.create_task(self.ws.start_server(self._on_ws))

--- a/code/client/client.py
+++ b/code/client/client.py
@@ -161,6 +161,8 @@ class ClientListener:
                 return default
         self.sitemap._startup_delay = _db_int_sync("SYNC_STARTUP_DELAY", 15)
         self.sitemap._inter_guild_delay = _db_int_sync("SYNC_INTER_GUILD_DELAY", 3)
+        _rand_raw = (self.db.get_config("SYNC_RANDOMIZE_ORDER", "") or "").strip().lower()
+        self.sitemap._randomize_order = _rand_raw not in ("0", "false", "no") if _rand_raw else True
         self.ui_controller = ClientUiController(
             bus=self.bus,
             admin_base_url=self.config.ADMIN_WS_URL,

--- a/code/client/sitemap.py
+++ b/code/client/sitemap.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 import asyncio
 import logging
+from collections import deque
 from typing import Any, List, Dict, Optional, Set
 import discord
 
@@ -26,6 +27,14 @@ class SitemapService:
         self._dirty_guild_ids: Set[int] = set()
         self._dirty_lock = asyncio.Lock()
         self._send_lock = asyncio.Lock()
+
+        # ── Smart queue ──
+        self._queue: deque[int] = deque()    # ordered guild IDs to process
+        self._queue_set: Set[int] = set()    # fast lookup for dedup
+        self._queue_lock = asyncio.Lock()
+        self._queue_task: Optional[asyncio.Task] = None
+        self._startup_delay: int = 15        # seconds before first sync
+        self._inter_guild_delay: int = 3     # seconds between guilds
 
     def _pick_guild(self) -> Optional[discord.Guild]:
         return self.bot.guilds[0] if self.bot.guilds else None
@@ -100,6 +109,185 @@ class SitemapService:
             g = self.bot.get_guild(int(gid))
             if g:
                 yield g
+
+    def enqueue(self, guild_id: int) -> None:
+        """Add a guild to the processing queue with deduplication.
+
+        If the guild is already queued, it keeps its position (the newer
+        data will be fetched when we get to it). If not, it's appended.
+        """
+        gid = int(guild_id)
+        mapped = set(self._mapped_original_ids())
+        if gid not in mapped:
+            self.logger.debug(
+                "[sitemap] Ignoring enqueue for unmapped origin %s", gid
+            )
+            return
+
+        if gid not in self._queue_set:
+            self._queue.append(gid)
+            self._queue_set.add(gid)
+            self.logger.debug("[sitemap] Queued guild %s (queue=%d)", gid, len(self._queue))
+
+        self._ensure_processor()
+
+    def enqueue_all(self) -> None:
+        """Queue all mapped guilds for sitemap processing."""
+        for gid in self._mapped_original_ids():
+            gid = int(gid)
+            if gid not in self._queue_set:
+                self._queue.append(gid)
+                self._queue_set.add(gid)
+        if self._queue:
+            self.logger.info(
+                "[sitemap] Queued %d guilds for sync", len(self._queue)
+            )
+        self._ensure_processor()
+
+    def _ensure_processor(self) -> None:
+        """Start the queue processor if not already running."""
+        if self._queue_task is None or self._queue_task.done():
+            self._queue_task = asyncio.create_task(self._process_queue())
+
+    async def _process_queue(self) -> None:
+        """Process queued guilds sequentially with delays between each."""
+        import time as _time
+        total = len(self._queue)
+        processed = 0
+        failed = 0
+        t_start = _time.monotonic()
+
+        self.logger.info(
+            "[sitemap] Processing %d guild(s) (delay=%ds between each)",
+            total, self._inter_guild_delay,
+        )
+
+        while self._queue:
+            gid = self._queue.popleft()
+            self._queue_set.discard(gid)
+            processed += 1
+
+            g = self.bot.get_guild(gid)
+            if not g:
+                self.logger.warning(
+                    "[sitemap] [%d/%d] Guild %s not found in cache, skipping",
+                    processed, total, gid,
+                )
+                failed += 1
+                continue
+
+            try:
+                clones = self.db.get_clone_guild_ids_for_origin(gid) or [None]
+            except Exception:
+                self.logger.exception(
+                    "[sitemap] [%d/%d] Failed to get clones for %s",
+                    processed, total, g.name,
+                )
+                failed += 1
+                continue
+
+            clone_count = len(clones)
+            self.logger.debug(
+                "[sitemap] [%d/%d] Building sitemap for %s (%d clone(s))",
+                processed, total, g.name, clone_count,
+            )
+
+            for cg in clones:
+                clone_id = int(cg) if cg is not None else None
+                try:
+                    t0 = _time.monotonic()
+                    if clone_id is None:
+                        sm = await self.build_for_guild(g)
+                    else:
+                        sm = await self.build_for_guild_and_clone(g, clone_id)
+
+                    build_ms = round((_time.monotonic() - t0) * 1000)
+
+                    if sm:
+                        await self.ws.send({"type": "sitemap", "data": sm})
+                        label = self._mapping_label(g.id, g.name, clone_id)
+                        ch_count = sum(
+                            len(c.get("channels", [])) for c in sm.get("categories", [])
+                        ) + len(sm.get("standalone_channels", []))
+                        forums = len(sm.get("forums", []))
+                        threads = len(sm.get("threads", []))
+                        roles = len(sm.get("roles", []))
+                        emojis = len(sm.get("emojis", []))
+                        stickers = len(sm.get("stickers", []))
+
+                        parts = [f"{ch_count} ch"]
+                        if forums: parts.append(f"{forums} forums")
+                        if threads: parts.append(f"{threads} threads")
+                        parts.append(f"{roles} roles")
+                        if emojis: parts.append(f"{emojis} emoji")
+                        if stickers: parts.append(f"{stickers} stickers")
+                        parts.append(f"{build_ms}ms")
+
+                        self.logger.info(
+                            "[📩] Sitemap sent for %s (%s)",
+                            label, ", ".join(parts),
+                        )
+                    else:
+                        self.logger.warning(
+                            "[sitemap] [%d/%d] Empty sitemap for %s clone %s",
+                            processed, total, g.name, clone_id,
+                        )
+
+                except discord.RateLimited as e:
+                    wait = e.retry_after + 1.0
+                    self.logger.warning(
+                        "[sitemap] Rate limited building %s, sleeping %.1fs",
+                        g.name, wait,
+                    )
+                    await asyncio.sleep(wait)
+                    if gid not in self._queue_set:
+                        self._queue.appendleft(gid)
+                        self._queue_set.add(gid)
+                        total += 1
+                    break
+
+                except discord.HTTPException as e:
+                    if e.status == 429:
+                        retry_after = 5.0
+                        try:
+                            if isinstance(e.json, dict):
+                                retry_after = float(e.json.get("retry_after", 5.0))
+                        except Exception:
+                            pass
+                        wait = retry_after + 1.0
+                        self.logger.warning(
+                            "[sitemap] HTTP 429 on %s, sleeping %.1fs",
+                            g.name, wait,
+                        )
+                        await asyncio.sleep(wait)
+                        if gid not in self._queue_set:
+                            self._queue.appendleft(gid)
+                            self._queue_set.add(gid)
+                            total += 1
+                        break
+
+                    failed += 1
+                    self.logger.exception(
+                        "[sitemap] HTTP error for %s clone %s: %s",
+                        g.name, clone_id, e,
+                    )
+
+                except Exception as e:
+                    failed += 1
+                    self.logger.exception(
+                        "[sitemap] Failed for %s clone %s: %s",
+                        g.name, clone_id, e,
+                    )
+
+            # Delay between guilds if more in queue
+            if self._queue:
+                await asyncio.sleep(self._inter_guild_delay)
+
+        elapsed = round(_time.monotonic() - t_start, 1)
+        self.logger.info(
+            "[sitemap] Sync complete: %d processed, %d failed (%.1fs)",
+            processed, failed, elapsed,
+        )
 
     def schedule_sync(self, guild_id: int | None, delay: float = 1.0) -> None:
         mapped = set(self._mapped_original_ids())
@@ -304,22 +492,17 @@ class SitemapService:
                     mapping_id,
                 )
 
-    async def build_and_send_all(self, max_concurrency: int = 10) -> None:
-        async with self._send_lock:
+    async def build_and_send_all(self) -> None:
+        self._cancel_pending_debounce()
+        self._dirty_guild_ids.clear()
 
-            self._cancel_pending_debounce()
-            self._dirty_guild_ids.clear()
+        origin_ids = self._mapped_original_ids()
 
-            origin_ids = self._mapped_original_ids()
+        if not origin_ids:
+            self.logger.info("[⚠️] No guild mappings found. Server cloning is disabled.")
+            return
 
-            if not origin_ids:
-                self.logger.info("[⚠️] No guild mappings found. Server cloning is disabled.")
-                return
-
-            await self._build_and_send_selected(
-                origin_ids,
-                max_concurrency=max_concurrency,
-            )
+        self.enqueue_all()
 
     async def build_for_guild(
         self, guild: "discord.Guild", cloned_guild_id: int | None = None
@@ -808,7 +991,6 @@ class SitemapService:
                 entry["overwrites"] = self._serialize_role_overwrites(forum)
             sitemap["forums"].append(entry)
 
-        seen = {t["id"] for t in sitemap["threads"]}
         for row in self.db.get_all_threads():
             try:
                 orig_tid = int(row["original_thread_id"])
@@ -818,6 +1000,11 @@ class SitemapService:
                     else None
                 )
             except (TypeError, ValueError):
+                continue
+
+            # Skip threads that don't belong to this guild
+            row_gid = row.get("original_guild_id")
+            if row_gid is not None and int(row_gid) != guild.id:
                 continue
 
             thr = guild.get_channel(orig_tid)
@@ -1138,8 +1325,8 @@ class SitemapService:
             if not dirty:
                 dirty = list(self._mapped_original_ids())
 
-            async with self._send_lock:
-                await self._build_and_send_selected(dirty)
+            for gid in dirty:
+                self.enqueue(gid)
 
         finally:
             self._debounce_task = None

--- a/code/client/sitemap.py
+++ b/code/client/sitemap.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 import asyncio
 import logging
+import random
 from collections import deque
 from typing import Any, List, Dict, Optional, Set
 import discord
@@ -35,6 +36,7 @@ class SitemapService:
         self._queue_task: Optional[asyncio.Task] = None
         self._startup_delay: int = 15        # seconds before first sync
         self._inter_guild_delay: int = 3     # seconds between guilds
+        self._randomize_order: bool = True   # shuffle guild order
 
     def _pick_guild(self) -> Optional[discord.Guild]:
         return self.bot.guilds[0] if self.bot.guilds else None
@@ -133,11 +135,12 @@ class SitemapService:
 
     def enqueue_all(self) -> None:
         """Queue all mapped guilds for sitemap processing."""
-        for gid in self._mapped_original_ids():
-            gid = int(gid)
-            if gid not in self._queue_set:
-                self._queue.append(gid)
-                self._queue_set.add(gid)
+        ids = [int(gid) for gid in self._mapped_original_ids() if int(gid) not in self._queue_set]
+        if self._randomize_order and ids:
+            random.shuffle(ids)
+        for gid in ids:
+            self._queue.append(gid)
+            self._queue_set.add(gid)
         if self._queue:
             self.logger.info(
                 "[sitemap] Queued %d guilds for sync", len(self._queue)

--- a/website/docs/configuration/advanced.md
+++ b/website/docs/configuration/advanced.md
@@ -160,6 +160,7 @@ Configure sync timing on the **Configuration** page under the **Sync Settings** 
 |---------|---------|-------------|
 | Startup Delay | 15s | Wait time after login before building sitemaps |
 | Inter-Guild Delay | 3s | Pause between each server during startup sync |
+| Randomize Order | On | Process servers in a random order each startup to avoid predictable patterns |
 
 ### Rate limit handling
 

--- a/website/docs/configuration/advanced.md
+++ b/website/docs/configuration/advanced.md
@@ -148,10 +148,35 @@ Copycord automatically prunes log files to prevent them from growing indefinitel
 
 The pruner uses memory-efficient seek-based reading — only the tail of the file is loaded into memory, even for very large log files. Writes are atomic (via temp file) to prevent data loss.
 
-## Rate limit behavior
+## Sync timing
 
-Copycord relies on discord.py's native rate limit handling for structure sync operations (channel creation, editing, role operations, etc.). When Discord returns a `429 Too Many Requests` response, the library automatically waits the required `Retry-After` duration before retrying.
+When the client starts, it scans each server you're cloning and sends the full structure (channels, roles, emojis, stickers) to the bot so it knows what to sync. Servers are processed one at a time with a delay between each to avoid hitting Discord's rate limits.
+
+After the initial startup sync, all changes are detected in real time via Discord gateway events — no periodic re-syncing is needed.
+
+Configure sync timing on the **Configuration** page under the **Sync Settings** card:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Startup Delay | 15s | Wait time after login before building sitemaps |
+| Inter-Guild Delay | 3s | Pause between each server during startup sync |
+
+### Rate limit handling
+
+If Discord returns a `429 Too Many Requests` response during sitemap generation, Copycord extracts the `retry_after` value from the response and waits the required duration before retrying. The affected server is re-queued at the front of the processing queue so no data is lost.
 
 For webhook message sending, Copycord uses a lightweight rate limiter (5 per 2.5s per webhook) to stay within Discord's message rate limits.
+
+### Stress testing
+
+To test how the system handles rate limits under load, enable the stress test mode via environment variable:
+
+```yaml
+client:
+  environment:
+    SITEMAP_STRESS_TEST: "true"
+```
+
+This continuously loops sitemap generation for all servers until the client is stopped. Only use this for testing — never in production.
 
 If you're using proxies for the client, traffic is routed through the proxy IP, keeping your real IP hidden from Discord.

--- a/website/docs/features/structure-sync.md
+++ b/website/docs/features/structure-sync.md
@@ -14,20 +14,20 @@ Copycord continuously watches source servers for structural changes and mirrors 
 | Event | Action in clone | Configurable |
 |-------|----------------|-------------|
 | Channel created | New channel created in clone | Always on |
-| Channel deleted | Clone channel deleted | `DELETE_CHANNELS` |
-| Channel renamed | Clone channel renamed | `RENAME_CHANNELS` |
-| Channel repositioned | Clone channel repositioned | `REPOSITION_CHANNELS` |
-| Topic changed | Clone topic updated | `SYNC_CHANNEL_TOPIC` |
-| NSFW toggled | Clone NSFW updated | `SYNC_CHANNEL_NSFW` |
-| Slowmode changed | Clone slowmode updated | `SYNC_CHANNEL_SLOWMODE` |
-| Permissions changed | Clone permissions updated | `MIRROR_CHANNEL_PERMISSIONS` |
+| Channel deleted | Clone channel deleted | Delete Removed Channels |
+| Channel renamed | Clone channel renamed | Rename Channels |
+| Channel repositioned | Clone channel repositioned | Reposition Channels |
+| Topic changed | Clone topic updated | Sync Channel Topic |
+| NSFW toggled | Clone NSFW updated | Sync NSFW Flag |
+| Slowmode changed | Clone slowmode updated | Sync Slowmode |
+| Permissions changed | Clone permissions updated | Mirror Channel Permissions |
 
 ### Threads
 
 | Event | Action in clone |
 |-------|----------------|
 | Thread created | Matching thread created |
-| Thread deleted | Clone thread removed (`DELETE_THREADS`) |
+| Thread deleted | Clone thread removed (Delete Removed Threads) |
 | Thread renamed | Clone thread renamed |
 | Thread archived/unarchived | Clone thread updated |
 
@@ -35,32 +35,32 @@ Copycord continuously watches source servers for structural changes and mirrors 
 
 | Event | Action in clone | Configurable |
 |-------|----------------|-------------|
-| Role created | New role created in clone | `CLONE_ROLES` |
-| Role deleted | Clone role deleted | `DELETE_ROLES` |
-| Role renamed | Clone role renamed | `UPDATE_ROLES` |
-| Color changed | Clone role color updated | `UPDATE_ROLES` |
-| Permissions changed | Clone permissions updated | `MIRROR_ROLE_PERMISSIONS` |
-| Hoist toggled | Clone hoist updated | `UPDATE_ROLES` |
-| Position changed | Clone position updated | `REARRANGE_ROLES` |
-| Icon changed | Clone icon updated | `CLONE_ROLE_ICONS` |
+| Role created | New role created in clone | Clone Roles |
+| Role deleted | Clone role deleted | Delete Removed Roles |
+| Role renamed | Clone role renamed | Update Role Properties |
+| Color changed | Clone role color updated | Update Role Properties |
+| Permissions changed | Clone permissions updated | Mirror Role Permissions |
+| Hoist toggled | Clone hoist updated | Update Role Properties |
+| Position changed | Clone position updated | Rearrange Roles |
+| Icon changed | Clone icon updated | Clone Role Icons |
 
 ### Emojis and Stickers
 
-| Event | Action in clone |
-|-------|----------------|
-| Emoji added | New emoji cloned | `CLONE_EMOJI` |
-| Emoji removed | Clone emoji deleted | `CLONE_EMOJI` |
-| Sticker added | New sticker cloned | `CLONE_STICKER` |
-| Sticker removed | Clone sticker deleted | `CLONE_STICKER` |
+| Event | Action in clone | Configurable |
+|-------|----------------|-------------|
+| Emoji added | New emoji cloned | Clone Emoji |
+| Emoji removed | Clone emoji deleted | Clone Emoji |
+| Sticker added | New sticker cloned | Clone Stickers |
+| Sticker removed | Clone sticker deleted | Clone Stickers |
 
-### Guild-level properties
+### Server Identity
 
 | Event | Configurable |
 |-------|-------------|
-| Server icon changed | `CLONE_GUILD_ICON` |
-| Server banner changed | `CLONE_GUILD_BANNER` |
-| Splash screen changed | `CLONE_GUILD_SPLASH` |
-| Description changed | `SYNC_GUILD_DESCRIPTION` |
+| Server icon changed | Clone Server Icon |
+| Server banner changed | Clone Server Banner |
+| Splash screen changed | Clone Invite Splash |
+| Description changed | Sync Server Description |
 
 ## How it works
 
@@ -77,9 +77,9 @@ The client self-bot receives Discord gateway events for every change in the sour
 - `GUILD_UPDATE`
 - `THREAD_CREATE/DELETE/UPDATE`
 
-### 2. Periodic full sync
+### 2. Startup sync
 
-A comprehensive structure comparison runs periodically (default: every 60 minutes). This catches any changes that might have been missed during downtime or network interruptions.
+When the client starts, it builds and sends a full sitemap for each server. Servers are processed one at a time with a configurable delay between each (default 3 seconds) to avoid rate limits. After startup, all changes are handled by real-time events — no periodic re-syncing is needed.
 
 ## Sync architecture
 


### PR DESCRIPTION
## Summary
- **Startup-only sync** — Sitemaps are built once on startup, no more hourly periodic re-sync. All changes after startup are handled by real-time gateway events.
- **Sequential queue** — Guilds processed one at a time with configurable delay between each (default 3s) to avoid rate limits and token revocation
- **Smart deduplication** — If a guild is already queued and a new sitemap request comes in, it keeps its queue position and builds fresh data when processed
- **Rate limit handling** — Catches 429 responses, extracts `retry_after`, sleeps, and re-queues the guild at the front
- **Randomized order** — Guilds are shuffled each startup to avoid predictable API patterns (configurable, on by default)
- **Sync Settings card** — New UI card on the Configuration page with Startup Delay, Inter-Guild Delay, and Randomize Order settings
- **Detailed logging** — Progress counter, build time per sitemap, channel/role/emoji/sticker counts, and sync completion summary
- **Stress test mode** — `SITEMAP_STRESS_TEST=true` env var loops sitemaps continuously for rate limit testing