### PR TITLE
Ft/add bot button and UI dashboard enhancments

### DIFF
--- a/code/admin/app.py
+++ b/code/admin/app.py
@@ -704,15 +704,15 @@ async def _check_client_token_valid(raw_token: str) -> bool:
         return False
 
 
-async def _check_server_token_valid(bot_token: str) -> bool:
+async def _check_server_token_valid(bot_token: str) -> tuple[bool, Optional[str]]:
     """
-    Returns True if SERVER_TOKEN (bot token) is valid and actually a bot.
-    We hit /users/@me with Authorization: Bot <token>.
+    Returns (valid, bot_user_id) — checks if SERVER_TOKEN is valid and a bot.
+    The bot_user_id is the same as the application/client ID for invite URLs.
     """
     token = (bot_token or "").strip()
     if not token:
         LOGGER.debug("_check_server_token_valid | no token provided")
-        return False
+        return False, None
 
     url = f"{DISCORD_API_BASE}/users/@me"
     headers = {
@@ -757,14 +757,21 @@ async def _check_server_token_valid(bot_token: str) -> bool:
                         "_check_server_token_valid | token is not a bot user; rejecting for SERVER_TOKEN use"
                     )
 
-                return ok
+                # Store the bot ID for invite URL generation
+                if ok and uid:
+                    try:
+                        db.set_config("BOT_CLIENT_ID", str(uid))
+                    except Exception:
+                        pass
+
+                return ok, uid if ok else None
     except Exception as e:
         LOGGER.warning(
             "_check_server_token_valid | exception=%s bot_token=%s",
             repr(e),
             _redact_token(token),
         )
-        return False
+        return False, None
 
 
 async def _verify_tokens_for_save(values: dict[str, str]) -> list[str]:
@@ -794,12 +801,13 @@ async def _verify_tokens_for_save(values: dict[str, str]) -> list[str]:
         return errs
 
     client_ok = await _check_client_token_valid(raw_client)
-    server_ok = await _check_server_token_valid(raw_server)
+    server_ok, _bot_id = await _check_server_token_valid(raw_server)
 
     LOGGER.debug(
-        "_verify_tokens_for_save | results client_ok=%s server_ok=%s",
+        "_verify_tokens_for_save | results client_ok=%s server_ok=%s bot_id=%s",
         client_ok,
         server_ok,
+        _bot_id,
     )
 
     if not client_ok:
@@ -2002,11 +2010,18 @@ async def api_validate_tokens():
     )
     ok = not errs
 
+    bot_client_id = None
+    try:
+        bot_client_id = (db.get_config("BOT_CLIENT_ID", "") or "").strip() or None
+    except Exception:
+        pass
+
     return JSONResponse(
         {
             "ok": ok,
             "has_tokens": True,
             "errors": errs,
+            "bot_client_id": bot_client_id,
         }
     )
 

--- a/code/admin/frontend/src/js/app.js
+++ b/code/admin/frontend/src/js/app.js
@@ -1866,6 +1866,13 @@
       } else {
         highlightTokenInputsFromErrors([]);
       }
+
+      // Enable invite button if bot client ID is available
+      const inviteBtn = document.getElementById("bot-invite-btn");
+      if (inviteBtn && data.bot_client_id) {
+        inviteBtn.href = `https://discord.com/oauth2/authorize?client_id=${data.bot_client_id}&permissions=8&integration_type=0&scope=bot`;
+        inviteBtn.classList.remove("bot-invite-disabled");
+      }
     } catch (err) {
       console.error("Token validation on load failed:", err);
     } finally {
@@ -5622,6 +5629,18 @@
         localStorage.setItem("cpc.sync-card-open", syncCard.open ? "1" : "0");
       });
     }
+
+    // Persist open/closed state for Global Config and Cloning Config
+    ["global-config-card", "guild-config-card"].forEach(id => {
+      const card = document.getElementById(id);
+      if (!card) return;
+      const key = `cpc.${id}-open`;
+      const saved = localStorage.getItem(key);
+      if (saved !== null) card.open = saved === "1";
+      card.addEventListener("toggle", () => {
+        localStorage.setItem(key, card.open ? "1" : "0");
+      });
+    });
 
     loadSyncSettings();
   });

--- a/code/admin/frontend/src/js/app.js
+++ b/code/admin/frontend/src/js/app.js
@@ -9,53 +9,41 @@
   let FILTER_OBJECTS_KIND = null;
   let FILTER_OBJECTS_CATMAP = null;
   let lastRunning = null;
-  let tooltipEl = null;
   let cModal, cTitle, cBody, cBtnOk, cBtnX, cBtnCa, cBack;
   let confirmResolve = null;
   let confirmReject = null;
   const UPTIME_KEY = (role) => `cpc:uptime:${role}`;
   const ICONS = {
     trash: `
-      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round"
-          d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
       </svg>
     `,
     settings: `
-      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round"
-          d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
-        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915"/><circle cx="12" cy="12" r="3"/>
       </svg>
     `,
     filters: `
-      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round"
-          d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z" />
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M10 20a1 1 0 0 0 .553.895l2 1A1 1 0 0 0 14 21v-7a2 2 0 0 1 .517-1.341L21.74 4.67A1 1 0 0 0 21 3H3a1 1 0 0 0-.742 1.67l7.225 7.989A2 2 0 0 1 10 14z"/>
       </svg>
     `,
     pause: `
-      <svg viewBox="0 0 24 24" width="20" height="20"
-          fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-        <rect x="7" y="5" width="3.5" height="14" rx="1"></rect>
-        <rect x="13.5" y="5" width="3.5" height="14" rx="1"></rect>
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <rect x="14" y="3" width="5" height="18" rx="1"/><rect x="5" y="3" width="5" height="18" rx="1"/>
       </svg>
     `,
     play: `
-      <svg viewBox="0 0 24 24" width="20" height="20"
-          fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round"
-              d="M8 5.75v12.5a.75.75 0 0 0 1.137.624l8-6.25a.75.75 0 0 0 0-1.248l-8-6.25A.75.75 0 0 0 8 5.75z" />
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z"/>
       </svg>
     `,
-
     clone: `
-    <svg viewBox="0 0 24 24" width="20" height="20" fill="none"
-          stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-      <rect x="9" y="9" width="10" height="10" rx="2"></rect>
-      <rect x="5" y="5" width="10" height="10" rx="2"></rect>
-    </svg>
-  `,
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+      </svg>
+    `,
   };
 
   let mapValidated = false;
@@ -581,80 +569,6 @@
   let uiSockTimer = null;
   let currentInterval = 4000;
 
-  function ensureTooltipEl() {
-    if (!tooltipEl) {
-      tooltipEl = document.createElement("div");
-      tooltipEl.className = "lock-tooltip";
-      tooltipEl.innerHTML = `
-      <div class="lock-tooltip-text">Stop the bot to edit server mappings</div>
-      <div class="lock-tooltip-arrow"></div>
-    `;
-      document.body.appendChild(tooltipEl);
-    }
-    return tooltipEl;
-  }
-
-  let lastTooltipUpdate = 0;
-  function showTooltip(x, y, force) {
-    const now = Date.now();
-    if (!force && now - lastTooltipUpdate < 50) return;
-    lastTooltipUpdate = now;
-
-    const tip = ensureTooltipEl();
-
-    const offsetY = 16;
-    tip.style.left = x + "px";
-    tip.style.top = y - offsetY + "px";
-    tip.style.opacity = "1";
-  }
-
-  function hideTooltip() {
-    if (tooltipEl) {
-      tooltipEl.style.opacity = "0";
-    }
-  }
-
-  function attachLockOverlay(card) {
-    if (card.querySelector(".guild-card-lock-overlay")) return;
-
-    const cs = window.getComputedStyle(card);
-    if (cs.position === "static") {
-      card.style.position = "relative";
-    }
-
-    const overlay = document.createElement("div");
-    overlay.className = "guild-card-lock-overlay";
-
-    const kill = (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-    };
-    overlay.addEventListener("click", kill);
-    overlay.addEventListener("mousedown", kill);
-    overlay.addEventListener("mouseup", kill);
-    overlay.addEventListener("touchstart", kill);
-    overlay.addEventListener("touchend", kill);
-
-    overlay.addEventListener("mouseenter", (e) => {
-      showTooltip(e.clientX, e.clientY, true);
-    });
-
-    overlay.addEventListener("mousemove", (e) => {
-      showTooltip(e.clientX, e.clientY, false);
-    });
-
-    overlay.addEventListener("mouseleave", () => {
-      hideTooltip();
-    });
-
-    card.appendChild(overlay);
-  }
-
-  function detachLockOverlay(card) {
-    const overlay = card.querySelector(".guild-card-lock-overlay");
-    if (overlay) overlay.remove();
-  }
-
   function setGlobalConfigLocked(running) {
     const cfgForm = document.getElementById("cfg-form");
     const saveBtn = document.getElementById("cfg-save-btn");
@@ -739,13 +653,12 @@
     cards.forEach((card) => {
       if (running) {
         card.classList.add("locked");
-        attachLockOverlay(card);
+        card.title = "Stop the bots to edit mappings";
       } else {
         card.classList.remove("locked");
-        detachLockOverlay(card);
+        card.title = "";
       }
     });
-    if (!running) hideTooltip();
   }
 
   async function fetchAndRenderStatus() {
@@ -3857,80 +3770,70 @@
           : "Pause cloning for this mapping";
 
         const statusBadgeHtml = isPaused
-          ? `<span class="status-pill status-pill-paused">Paused</span>`
+          ? `<span class="guild-card-paused-icon" title="Paused"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.268 21a2 2 0 0 0 3.464 0"/><path d="M17 17H4a1 1 0 0 1-.74-1.673C4.59 13.956 6 12.499 6 8a6 6 0 0 1 .258-1.742"/><path d="m2 2 20 20"/><path d="M8.668 3.01A6 6 0 0 1 18 8c0 2.687.77 4.653 1.707 6.05"/></svg></span>`
           : "";
+
+        const hostName = escapeHtml(m.original_guild_name || `ID: ${m.original_guild_id}`);
 
         return `
       <div class="guild-card ${isPaused ? "is-paused" : "is-active"}"
            data-id="${m.mapping_id}"
            data-status="${statusRaw}">
-        <div class="guild-card-logo">
-          <img src="${iconSrc}" alt="" class="guild-card-logo-img">
-        </div>
 
         <div class="guild-card-inner">
-          <div class="guild-card-main">
-            <div class="guild-card-name">
-              <div class="guild-card-name-title"
-                   title="${escapeHtml(m.mapping_name || "")}">
+          <div class="guild-card-header">
+            <img src="${iconSrc}" alt="" class="guild-card-avatar">
+            <div class="guild-card-info">
+              <div class="guild-card-name-title" title="${escapeHtml(m.mapping_name || "")}">
                 ${escapeHtml(m.mapping_name || "")}
               </div>
+              <div class="guild-card-route">${hostName}</div>
             </div>
-
-            <div class="guild-card-actions">
-              <button class="btn-icon edit-mapping-btn"
-                      data-id="${m.mapping_id}"
-                      aria-label="Edit mapping"
-                      title="Settings">
-                ${ICONS.settings}
-              </button>
-
-              <button class="btn-icon mapping-filters-btn"
-                      data-id="${m.mapping_id}"
-                      aria-label="Filters for this mapping"
-                      title="Filters">
-                ${ICONS.filters}
-              </button>
-
-              <button class="btn-icon mapping-status-btn ${
-                isPaused ? "is-paused" : "is-active"
-              }"
-                      data-id="${m.mapping_id}"
-                      type="button"
-                      aria-pressed="${isPaused ? "true" : "false"}"
-                      aria-label="${statusLabel}"
-                      title="${statusLabel}">
-                ${statusIcon}
-              </button>
-
-              <button class="btn-icon clone-mapping-btn"
-                      data-id="${m.mapping_id}"
-                      aria-label="Clone mapping"
-                      title="Clone mapping">
-                ${ICONS.clone}
-              </button>
-
-              <button
-                class="btn-icon delete-mapping-btn"
-                type="button"
-                data-action="delete"
-                data-id="${m.mapping_id}"
-                aria-label="Delete mapping"
-                title="Delete mapping">
-                ${ICONS.trash}
-              </button>
-            </div>
+            ${statusBadgeHtml}
           </div>
 
-          ${
-            statusBadgeHtml
-              ? `
-            <div class="guild-card-status">
-              ${statusBadgeHtml}
-            </div>
-          `
-              : ""
-          }
+          <div class="guild-card-actions">
+            <button class="btn-icon edit-mapping-btn"
+                    data-id="${m.mapping_id}"
+                    aria-label="Edit mapping"
+                    title="Settings">
+              ${ICONS.settings}
+            </button>
+
+            <button class="btn-icon mapping-filters-btn"
+                    data-id="${m.mapping_id}"
+                    aria-label="Filters for this mapping"
+                    title="Filters">
+              ${ICONS.filters}
+            </button>
+
+            <button class="btn-icon mapping-status-btn ${isPaused ? "is-paused" : "is-active"}"
+                    data-id="${m.mapping_id}"
+                    type="button"
+                    aria-pressed="${isPaused ? "true" : "false"}"
+                    aria-label="${statusLabel}"
+                    title="${statusLabel}">
+              ${statusIcon}
+            </button>
+
+            <button class="btn-icon clone-mapping-btn"
+                    data-id="${m.mapping_id}"
+                    aria-label="Clone mapping"
+                    title="Clone mapping">
+              ${ICONS.clone}
+            </button>
+
+            <span class="guild-card-action-spacer"></span>
+
+            <button class="btn-icon delete-mapping-btn"
+                    type="button"
+                    data-action="delete"
+                    data-id="${m.mapping_id}"
+                    aria-label="Delete mapping"
+                    title="Delete mapping">
+              ${ICONS.trash}
+            </button>
+          </div>
         </div>
       </div>
     `;
@@ -3946,8 +3849,7 @@
         title="Add new mapping"
       >
         <div class="new-card-inner">
-          <div class="new-card-plus">+</div>
-          <div class="new-card-label">Add Mapping</div>
+          <div class="new-card-plus"><svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m11 19-1.106-.552a2 2 0 0 0-1.788 0l-3.659 1.83A1 1 0 0 1 3 19.381V6.618a1 1 0 0 1 .553-.894l4.553-2.277a2 2 0 0 1 1.788 0l4.212 2.106a2 2 0 0 0 1.788 0l3.659-1.83A1 1 0 0 1 21 4.619V12"/><path d="M15 5.764V12"/><path d="M18 15v6"/><path d="M21 18h-6"/><path d="M9 3.236v15"/></svg></div>
         </div>
       </button>
     `;

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -202,6 +202,9 @@ th {
   flex-wrap: wrap;
   margin-top: 12px;
 }
+.flex-spacer {
+  flex: 1 1 0%;
+}
 .btns form {
   margin: 0;
   display: inline;
@@ -403,12 +406,6 @@ th {
   }
 }
 
-.badge-ok {
-  color: #c7f9cc;
-}
-.badge-stop {
-  color: #fecaca;
-}
 .small {
   font-size: 12px;
   opacity: 0.85;
@@ -1014,6 +1011,22 @@ table.runtime th:nth-child(3) {
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
   }
+}
+.status-chip {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 10px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--muted);
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.status-chip:empty {
+  display: none;
 }
 .runtime-container {
   width: 100%;
@@ -11291,6 +11304,41 @@ body.page-forwarding .fwd-no-match-sub {
   font-size: 15px;
   user-select: text;
   cursor: text;
+}
+.card-doc-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  opacity: 0.5;
+  transition: opacity 0.15s ease, color 0.15s ease;
+  text-decoration: none;
+}
+.card-doc-link:hover {
+  opacity: 1;
+  color: var(--accent, #a78bfa);
+}
+.bot-invite-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--accent, #a78bfa);
+  text-decoration: none;
+  opacity: 0.8;
+  transition: opacity 0.15s ease;
+}
+.bot-invite-btn:hover {
+  opacity: 1;
+}
+.bot-invite-btn.bot-invite-disabled {
+  opacity: 0.3;
+  pointer-events: none;
+  cursor: default;
+}
+.bot-invite-btn svg {
+  flex-shrink: 0;
 }
 .srv-proxy-chip {
   font-size: 11px;

--- a/code/admin/frontend/src/main.css
+++ b/code/admin/frontend/src/main.css
@@ -6657,29 +6657,35 @@ body.modal-open #bf-batchbar {
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 16px;
   margin-top: 16px;
-
-  max-height: 520px;
+  min-height: 180px;
+  max-height: 320px;
   overflow-y: auto;
-  padding-top: 8px;
-  padding-bottom: 8px;
-}
-
-.guild-mapping-list {
-  scrollbar-color: var(--accent) transparent;
+  padding: 8px 4px 8px 0;
   scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
 }
-
+.guild-mapping-list:hover {
+  scrollbar-color: var(--accent) transparent;
+}
 .guild-mapping-list::-webkit-scrollbar {
-  width: 8px;
+  width: 12px;
+  height: 12px;
 }
-
 .guild-mapping-list::-webkit-scrollbar-track {
   background: transparent;
+  border-radius: 12px;
 }
-
 .guild-mapping-list::-webkit-scrollbar-thumb {
-  background-color: var(--accent);
-  border-radius: 999px;
+  background: transparent;
+  border-radius: 12px;
+  transition: background 0.2s ease;
+}
+.guild-mapping-list:hover::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, var(--primary), var(--primary-700));
+  border: 2px solid transparent;
+}
+.guild-mapping-list::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, var(--primary-600), var(--primary-700));
 }
 
 .guild-card {
@@ -6687,20 +6693,16 @@ body.modal-open #bf-batchbar {
   display: flex;
   flex-direction: column;
   min-width: 0;
-  min-height: 120px;
-  padding: 14px 14px 12px;
+  padding: 12px;
 
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 12px;
   color: var(--text);
 
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.6);
-
-  isolation: isolate;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   overflow: hidden;
   text-align: left;
-  align-items: stretch;
 
   transition: border-color 0.15s ease, box-shadow 0.15s ease,
     transform 0.15s ease, background-color 0.15s ease;
@@ -6710,100 +6712,88 @@ body.modal-open #bf-batchbar {
   transform: translateY(-2px);
   border-color: var(--accent);
   background: rgba(27, 16, 48, 0.6);
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.75);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.6);
 }
 
 .guild-card-inner {
-  position: relative;
-  z-index: 2;
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  gap: 10px;
+  height: 100%;
 }
 
-.guild-card-logo {
-  position: absolute;
-  inset: 0;
+.guild-card-header {
   display: flex;
   align-items: center;
-  justify-content: center;
-  pointer-events: none;
-  z-index: 1;
-
-  opacity: 1;
-  filter: none;
-  mix-blend-mode: normal;
+  gap: 10px;
 }
 
-.guild-card-logo img {
-  width: 52px;
-  height: 52px;
-  max-width: 52px;
-  max-height: 52px;
-  opacity: 1;
-  object-fit: contain;
+.guild-card-avatar {
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
 }
 
-.guild-card-main {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  min-height: 38px;
-  margin-bottom: 0 !important;
-  width: 100%;
-}
-
-.guild-card-name {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 6px;
-  width: 100%;
+.guild-card-info {
+  flex: 1;
+  min-width: 0;
 }
 
 .guild-card-name-title {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  overflow: hidden;
-  max-width: 100%;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
   line-height: 1.3;
   color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
-  word-break: break-word;
-  white-space: normal;
+.guild-card-route {
+  font-size: 11px;
+  color: var(--muted);
+  opacity: 0.7;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
 }
 
 .guild-card-actions {
   display: flex;
-  gap: 6px;
-  flex-shrink: 0;
+  gap: 4px;
+  margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px solid var(--border, rgba(255, 255, 255, 0.06));
+}
+
+.guild-card-action-spacer {
+  flex: 1;
 }
 
 .guild-card .btn-icon {
-  width: 24px;
-  height: 24px;
-  min-height: 24px;
+  width: 28px;
+  height: 28px;
+  min-height: 28px;
   border-radius: 6px;
   font-size: 12px;
   line-height: 1;
   cursor: pointer;
 
   border: none;
-  background: #ffffff08;
-  color: var(--accent);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted);
 
   box-shadow: none;
-  transition: background-color 0.12s ease, border-color 0.12s ease,
-    color 0.12s ease, transform 0.08s ease;
+  transition: background-color 0.12s ease, color 0.12s ease, transform 0.08s ease;
 }
 
 .guild-card .btn-icon svg {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   display: block;
   stroke: currentColor;
   fill: none;
@@ -6814,9 +6804,8 @@ body.modal-open #bf-batchbar {
 }
 
 .guild-card .btn-icon:hover {
-  background: rgba(167, 139, 250, 0.08);
-  border-color: var(--accent);
-  color: var(--text);
+  background: rgba(167, 139, 250, 0.12);
+  color: var(--accent);
 }
 
 .guild-card .btn-icon:active {
@@ -6876,7 +6865,6 @@ body.modal-open #bf-batchbar {
 }
 
 .guild-card--new {
-  min-height: 140px;
   padding: 16px;
   background: rgba(255, 255, 255, 0.02);
   border: 1px dashed var(--border);
@@ -6904,11 +6892,9 @@ body.modal-open #bf-batchbar {
 }
 
 .guild-card--new .new-card-plus {
-  font-size: 56px;
-  font-weight: 600;
-  line-height: 1;
   color: var(--accent);
   user-select: none;
+  line-height: 0;
 }
 
 .guild-card--new:hover,
@@ -6942,8 +6928,9 @@ body.modal-open #bf-batchbar {
     padding: 14px;
   }
 
-  .guild-card--new .new-card-plus {
-    font-size: 48px;
+  .guild-card--new .new-card-plus svg {
+    width: 32px;
+    height: 32px;
   }
 }
 
@@ -7316,7 +7303,9 @@ body.modal-open {
 .guild-card.locked {
   opacity: 0.5;
   filter: grayscale(0.4);
-  cursor: default;
+  cursor: not-allowed;
+}
+.guild-card.locked .guild-card-inner {
   pointer-events: none;
 }
 
@@ -8420,18 +8409,24 @@ body.login-page {
   transform: none;
 }
 
-.guild-card.is-paused .guild-card-logo {
+.guild-card.is-paused .guild-card-avatar {
   opacity: 0.5;
-}
-
-.guild-card.is-paused:hover .guild-card-logo {
-  opacity: 0.6;
-}
-
-.guild-card.is-paused img,
-.guild-card.is-paused .guild-card-icon {
   filter: grayscale(60%);
 }
+.guild-card-paused-icon {
+  flex-shrink: 0;
+  color: var(--muted);
+  opacity: 0.4;
+  display: inline-flex;
+}
+.guild-card-paused-icon svg {
+  width: 20px;
+  height: 20px;
+}
+.guild-card.is-paused .guild-card-actions {
+  border-top-color: rgba(255, 255, 255, 0.06);
+}
+
 
 .status-pill {
   display: inline-flex;

--- a/code/admin/templates/index.html
+++ b/code/admin/templates/index.html
@@ -214,13 +214,13 @@
                 <td>Server</td>
                 <td><span id="server-state" class="badge">-</span></td>
                 <td id="server-uptime"></td>
-                <td id="server-status"></td>
+                <td><span id="server-status" class="status-chip"></span></td>
               </tr>
               <tr>
                 <td>Client</td>
                 <td><span id="client-state" class="badge">-</span></td>
                 <td id="client-uptime"></td>
-                <td id="client-status"></td>
+                <td><span id="client-status" class="status-chip"></span></td>
               </tr>
             </tbody>
           </table>
@@ -290,10 +290,19 @@
     "LOG_MAX_SIZE_MB": "Maximum size of each log file in megabytes before older entries are pruned. Set to 0 to disable pruning."
     } %}
 
-    <div class="card" id="global-config-card">
-      <h3>Global Configuration</h3>
+    <details class="card srv-proxy-card" id="global-config-card" open>
+      <summary class="srv-proxy-summary">
+        <h3>Global Configuration</h3>
+        <a href="https://copycord.github.io/Copycord/docs/getting-started/first-run" target="_blank" rel="noopener"
+           class="card-doc-link" title="View docs">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">
+            <path d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z"/>
+          </svg>
+        </a>
+        <span class="card-chev" aria-hidden="true">&#9662;</span>
+      </summary>
 
-      <form method="post" action="/save" id="cfg-form" novalidate>
+      <form method="post" action="/save" id="cfg-form" class="srv-proxy-body" novalidate>
         <div class="grid">
           {% set GC_NAMES = {
             "SERVER_TOKEN": "Server Token",
@@ -412,32 +421,59 @@
           <div class="btns">
             <button class="btn btn-ghost" type="submit" id="cfg-save-btn">Save</button>
             <button type="button" class="btn btn-ghost" id="cfg-cancel-btn">Cancel</button>
+            <span class="flex-spacer"></span>
+            <a id="bot-invite-btn" class="bot-invite-btn bot-invite-disabled" href="#" target="_blank" rel="noopener"
+               title="Invite your bot to a clone server">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/>
+                <path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/>
+              </svg>
+              Add Bot to Server
+            </a>
           </div>
         </div>
       </form>
-    </div>
+    </details>
 
-    <div class="card" id="guild-config-card">
-      <h3>Cloning Configuration</h3>
+    <details class="card srv-proxy-card" id="guild-config-card" open>
+      <summary class="srv-proxy-summary">
+        <h3>Cloning Configuration</h3>
+        <a href="https://copycord.github.io/Copycord/docs/configuration/cloning-options" target="_blank" rel="noopener"
+           class="card-doc-link" title="View docs">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">
+            <path d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z"/>
+          </svg>
+        </a>
+        <span class="card-chev" aria-hidden="true">&#9662;</span>
+      </summary>
 
-      <div class="guild-config-header">
-        <p class="text-subtle">
-          Map a source server to a target server to enable cloning for that pair
-        </p>
+      <div class="srv-proxy-body">
+        <div class="guild-config-header">
+          <p class="text-subtle">
+            Map a source server to a target server to enable cloning for that pair
+          </p>
 
-        <div class="guild-mapping-search">
-          <input id="mappingSearchInput" class="log-search-input" type="text" placeholder="Search mappings…"
-            aria-label="Search mappings" autocomplete="off" />
+          <div class="guild-mapping-search">
+            <input id="mappingSearchInput" class="log-search-input" type="text" placeholder="Search mappings…"
+              aria-label="Search mappings" autocomplete="off" />
+          </div>
         </div>
-      </div>
 
-      <div id="guild-mapping-list" class="guild-mapping-list"></div>
-    </div>
+        <div id="guild-mapping-list" class="guild-mapping-list"></div>
+      </div>
+    </details>
 
     <!-- ─── Sync Settings ─── -->
     <details class="card srv-proxy-card" id="sync-settings-card">
       <summary class="srv-proxy-summary">
         <h3>Sync Settings</h3>
+        <a href="https://copycord.github.io/Copycord/docs/configuration/advanced#sync-timing" target="_blank" rel="noopener"
+           class="card-doc-link" title="View docs">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">
+            <path d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z"/>
+          </svg>
+        </a>
         <span class="card-chev" aria-hidden="true">&#9662;</span>
       </summary>
       <div class="srv-proxy-body">
@@ -483,6 +519,12 @@
     <details class="card srv-proxy-card" id="srv-proxy-card">
       <summary class="srv-proxy-summary">
         <h3>Proxy</h3>
+        <a href="https://copycord.github.io/Copycord/docs/configuration/advanced#proxy-support" target="_blank" rel="noopener"
+           class="card-doc-link" title="View docs">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">
+            <path d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z"/>
+          </svg>
+        </a>
         <span class="srv-proxy-chip" id="srv-proxy-status"></span>
         <button type="button" class="srv-proxy-settings-btn" id="srv-proxy-settings-btn" title="Proxy Settings" onclick="event.preventDefault()">
           <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none"

--- a/website/docs/dashboard/overview.md
+++ b/website/docs/dashboard/overview.md
@@ -40,12 +40,13 @@ To change or remove the password:
 
 ## Starting and stopping bots
 
-The dashboard provides **Start** and **Stop** buttons for both the server and client bots. Both must be running for cloning to work:
-
-- **Server** (green indicator) — The Discord bot in your clone server
-- **Client** (green indicator) — The self-bot monitoring source servers
+The dashboard provides a **Start** button for both the server and client bots. Both must be running for cloning to work. Status chips show green "running" or red "stopped" with live uptime tracking.
 
 Valid tokens are required to start.
+
+### Add Bot to Server
+
+Once your bot token is validated, an **Add Bot to Server** button appears next to the Start button. Click it to open Discord's bot authorization page with the correct permissions pre-configured — no need to manually build an invite URL.
 
 ## Global configuration
 

--- a/website/docs/getting-started/first-run.md
+++ b/website/docs/getting-started/first-run.md
@@ -36,11 +36,15 @@ In the dashboard settings, add your Discord user ID to **Command Users**. This a
 3. Click **Copy User ID**
 :::
 
-## 4. Start the bots
+## 4. Add your bot to the clone server
 
-Click the **Start** buttons to launch both the server bot and client bot. The status indicators will turn green when both are connected.
+Once your tokens are saved and validated, an **Add Bot to Server** button appears on the dashboard. Click it to invite your bot to your clone server with the right permissions — no need to manually build an invite URL.
 
-## 5. Create a guild mapping
+## 5. Start the bots
+
+Click the **Start** button to launch both the server bot and client bot. The status chips will show green "running" when both are connected.
+
+## 6. Create a guild mapping
 
 A **guild mapping** links a source server to your clone server:
 
@@ -49,7 +53,7 @@ A **guild mapping** links a source server to your clone server:
 3. Select the **Clone Server** — the empty server where your bot is
 4. Click **Create**
 
-## 6. Watch the magic
+## 7. Watch the magic
 
 Once the mapping is created and both bots are running, Copycord will:
 


### PR DESCRIPTION
## Summary
- **Add Bot to Server** button in Global Configuration — auto-detects bot client ID during token validation, generates Discord OAuth2 invite link. Greyed out until a valid bot token is saved.
- **Status chips** — Bot status column styled as pill chips
- **Collapsible cards** — Global Configuration and Cloning Configuration now use the same collapse/expand pattern as Sync Settings and Proxy cards, with state persisted in localStorage
- **Doc links** — Each card header has a book icon linking to the relevant documentation page
- **Redesigned mapping cards** — Avatar + name + host server subtitle layout, action buttons in a bottom bar with delete separated to the right, Lucide icons throughout
- **Removed lock overlay animation** — Cards still lock when bots run but without the tooltip overlay. Native browser tooltip shows on hover instead.