### PR TITLE
Fix sqlite row access in sitemap

### DIFF
--- a/code/client/sitemap.py
+++ b/code/client/sitemap.py
@@ -17,6 +17,24 @@ from typing import Any, List, Dict, Optional, Set
 import discord
 
 
+def _row_get(row: Any, key: str, default: Any = None) -> Any:
+    if hasattr(row, "get"):
+        return row.get(key, default)
+
+    try:
+        keys = row.keys()
+    except AttributeError:
+        keys = ()
+
+    if key in keys:
+        try:
+            return row[key]
+        except (KeyError, IndexError, TypeError):
+            return default
+
+    return default
+
+
 class SitemapService:
     def __init__(self, bot, config, db, ws, logger=None):
         self.bot = bot
@@ -1006,7 +1024,7 @@ class SitemapService:
                 continue
 
             # Skip threads that don't belong to this guild
-            row_gid = row.get("original_guild_id")
+            row_gid = _row_get(row, "original_guild_id")
             if row_gid is not None and int(row_gid) != guild.id:
                 continue
 

--- a/code/server/guild_resolver.py
+++ b/code/server/guild_resolver.py
@@ -12,6 +12,24 @@ from __future__ import annotations
 from typing import Optional, Set
 
 
+def _row_get(row, key: str, default=None):
+    if hasattr(row, "get"):
+        return row.get(key, default)
+
+    try:
+        keys = row.keys()
+    except AttributeError:
+        keys = ()
+
+    if key in keys:
+        try:
+            return row[key]
+        except (KeyError, IndexError, TypeError):
+            return default
+
+    return default
+
+
 class GuildResolver:
     def __init__(self, db, config=None):
         self.db = db
@@ -31,10 +49,10 @@ class GuildResolver:
             active_ids: set[int] = set()
 
             for r in rows:
-                st = str(r.get("status", "active") or "active").strip().lower()
+                st = str(_row_get(r, "status", "active") or "active").strip().lower()
                 if st == "paused":
                     continue
-                if r.get("cloned_guild_id"):
+                if _row_get(r, "cloned_guild_id"):
                     active_ids.add(int(r["cloned_guild_id"]))
 
             return active_ids
@@ -45,7 +63,7 @@ class GuildResolver:
         row = self.db.get_mapping_by_clone(int(clone_guild_id))
         return (
             {int(row["original_guild_id"])}
-            if row and row.get("original_guild_id")
+            if row and _row_get(row, "original_guild_id")
             else set()
         )
 
@@ -75,8 +93,8 @@ class GuildResolver:
 
         if host_guild_id is not None:
             row = self.db.get_mapping_by_original(int(host_guild_id))
-            if row and row.get("cloned_guild_id"):
-                st = str(row.get("status", "active") or "active").strip().lower()
+            if row and _row_get(row, "cloned_guild_id"):
+                st = str(_row_get(row, "status", "active") or "active").strip().lower()
                 if st != "paused":
                     return int(row["cloned_guild_id"])
 

--- a/tests/test_guild_resolver.py
+++ b/tests/test_guild_resolver.py
@@ -1,0 +1,26 @@
+from server.guild_resolver import GuildResolver
+
+
+def _create_mapping(db, *, mapping_id="resolver-test", status="active"):
+    db.upsert_guild_mapping(
+        mapping_id=mapping_id,
+        mapping_name="Resolver Test",
+        original_guild_id=111,
+        original_guild_name="Source Server",
+        original_guild_icon_url=None,
+        cloned_guild_id=222,
+        cloned_guild_name="Clone Server",
+    )
+    db.update_mapping_status(mapping_id, status)
+
+
+def test_clones_for_host_reads_sqlite_rows(db):
+    _create_mapping(db)
+
+    assert GuildResolver(db).clones_for_host(111) == {222}
+
+
+def test_clones_for_host_skips_paused_sqlite_rows(db):
+    _create_mapping(db, status="paused")
+
+    assert GuildResolver(db).clones_for_host(111) == set()

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,0 +1,43 @@
+import importlib
+import sys
+import types
+
+
+def _import_sitemap(monkeypatch):
+    if "client.sitemap" in sys.modules:
+        return sys.modules["client.sitemap"]
+
+    monkeypatch.setitem(sys.modules, "discord", types.SimpleNamespace())
+    return importlib.import_module("client.sitemap")
+
+
+def test_row_get_supports_sqlite_row(db, monkeypatch):
+    sitemap = _import_sitemap(monkeypatch)
+
+    db.upsert_category_mapping(10, "Cat", 20, "Cat-C", 1, 2)
+    db.upsert_channel_mapping(
+        100,
+        "forum",
+        200,
+        None,
+        10,
+        20,
+        15,
+        original_guild_id=1,
+        cloned_guild_id=2,
+    )
+    db.upsert_forum_thread_mapping(
+        orig_thread_id=3000,
+        orig_thread_name="Thread 1",
+        clone_thread_id=4000,
+        forum_orig_id=100,
+        forum_clone_id=200,
+        original_guild_id=1,
+        cloned_guild_id=2,
+    )
+
+    row = db.get_all_threads()[0]
+
+    assert not hasattr(row, "get")
+    assert sitemap._row_get(row, "original_guild_id") == 1
+    assert sitemap._row_get(row, "missing_column", "fallback") == "fallback"


### PR DESCRIPTION
## Summary
- add row-safe lookup for sqlite3.Row values used by sitemap thread filtering
- apply the same lookup to guild resolver mapping rows
- add regression tests for sqlite row access in sitemap and guild resolver paths

## Tests
- uv run --no-project --with ruff ruff check code/client/sitemap.py code/server/guild_resolver.py tests/test_sitemap.py tests/test_guild_resolver.py
- PYTHONPATH=code uv run --no-project --with-requirements tests/requirements-test.txt --with pytest-asyncio python -m pytest tests -q