### PR TITLE
Fix components showing offline in the dashboard during idle periods

### DIFF
--- a/code/client/client.py
+++ b/code/client/client.py
@@ -982,6 +982,32 @@ class ClientListener:
         if self.proxy_rotator.enabled and self.proxy_rotator._current_proxy:
             self.proxy_rotator.report_success(self.proxy_rotator._current_proxy)
 
+    async def _status_heartbeat_loop(self):
+        """Periodically re-publish status so the admin watchdog keeps us online.
+
+        The admin marks a component offline after ~90s of bus silence. Incidental
+        log/event traffic normally refreshes that, but an otherwise-idle bot would
+        be shown offline while running fine. Gated on readiness so a genuine
+        disconnect or shutdown isn't masked by a stale "running" heartbeat.
+        """
+        while True:
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                return
+            try:
+                if self.bot.is_ready() and not self.bot.is_closed():
+                    who = getattr(
+                        getattr(self.bot, "user", None), "display_name", "(unknown)"
+                    )
+                    await self.bus.status(
+                        running=True,
+                        status=f"Logged in as {who}",
+                        discord={"ready": True},
+                    )
+            except Exception:
+                logger.debug("[status] heartbeat publish failed", exc_info=True)
+
     async def on_ready(self):
         await self.forwarding.start()
         self._reload_mapped_ids()
@@ -1001,6 +1027,16 @@ class ClientListener:
             status=msg,
             discord={"ready": True},
         )
+
+        # Keep re-publishing status so the admin's watchdog keeps us marked
+        # online during quiet periods (it presumes offline after ~90s of bus
+        # silence). Started once; survives gateway reconnects.
+        if (
+            getattr(self, "_status_hb_task", None) is None
+            or self._status_hb_task.done()
+        ):
+            self._status_hb_task = asyncio.create_task(self._status_heartbeat_loop())
+
         logger.info("[🤖] %s", msg)
 
         if self._sync_task is None or self._sync_task.done():
@@ -2586,6 +2622,9 @@ class ClientListener:
         Asynchronously shuts down the client.
         """
         logger.info("Shutting down client…")
+        hb = getattr(self, "_status_hb_task", None)
+        if hb is not None:
+            hb.cancel()
         self.ws.begin_shutdown()
         self.bus.begin_shutdown()
         with contextlib.suppress(Exception):

--- a/code/server/server.py
+++ b/code/server/server.py
@@ -792,6 +792,31 @@ class ServerReceiver:
         except Exception:
             logger.exception("Failed to summarize guild_mappings on startup")
 
+    async def _status_heartbeat_loop(self):
+        """Periodically re-publish status so the admin watchdog keeps us online.
+
+        The admin marks a component offline after ~90s of bus silence. Incidental
+        log/event traffic normally refreshes that, but an otherwise-idle bot would
+        be shown offline while running fine. Gated on readiness so a genuine
+        disconnect or shutdown isn't masked by a stale "running" heartbeat.
+        """
+        while not self._shutting_down:
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                return
+            if self._shutting_down:
+                return
+            try:
+                if self.bot.is_ready() and not self.bot.is_closed():
+                    await self.bus.status(
+                        running=True,
+                        status=f"Logged in as {self.bot.user.name}",
+                        discord={"ready": True},
+                    )
+            except Exception:
+                logger.debug("[status] heartbeat publish failed", exc_info=True)
+
     async def on_ready(self):
         """
         Event handler that is called when the bot is ready.
@@ -843,6 +868,12 @@ class ServerReceiver:
         msg = f"Logged in as {self.bot.user.name}"
 
         await self.bus.status(running=True, status=msg, discord={"ready": True})
+
+        # Keep re-publishing status so the admin's watchdog keeps us marked
+        # online during quiet periods (it presumes offline after ~90s of bus
+        # silence). Started once; survives gateway reconnects.
+        if getattr(self, "_status_hb_task", None) is None or self._status_hb_task.done():
+            self._status_hb_task = asyncio.create_task(self._status_heartbeat_loop())
 
         logger.info("[🤖] %s", msg)
 
@@ -12059,6 +12090,9 @@ class ServerReceiver:
             return
         self._shutting_down = True
         logger.info("Shutting down server...")
+        hb = getattr(self, "_status_hb_task", None)
+        if hb is not None:
+            hb.cancel()
         if getattr(self, "_send_tasks", None):
 
             for t in list(self._send_tasks):


### PR DESCRIPTION
## Problem
The admin dashboard marks a component offline after ~90s without any bus traffic. Normally incidental log/event activity keeps the status fresh, but a bot that's idle (no messages to clone) would be shown as offline even though it's running fine.

## Fix
The client and server now re-publish their status every 30 seconds while connected and ready:

- Added a `_status_heartbeat_loop` to both components that publishes `running: true` via the bus every 30s.
- The loop only publishes while the bot is ready and not closed, so a genuine disconnect or shutdown isn't masked by a stale heartbeat.
- Started once from `on_ready` (survives gateway reconnects) and cancelled cleanly on shutdown.
