### PR TITLE
fix(ci): add py-cord to test requirements so server test modules import

### DIFF
--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,5 +1,8 @@
 pytest==8.3.5
 httpx==0.28.1
+# Server-side `discord` package (keep in sync with code/server/requirements.txt).
+# Conflicts with the client's discord.py-self — client tests must not import `discord`.
+py-cord==2.7.2
 fastapi==0.116.1
 jinja2==3.1.6
 python-dotenv==1.2.2


### PR DESCRIPTION
Add `py-cord==2.7.2` to `tests/requirements-test.txt`, pinned to match
`code/server/requirements.txt`.